### PR TITLE
Fix crash when reading HiDGuardian registry

### DIFF
--- a/gremlin/hid_guardian.py
+++ b/gremlin/hid_guardian.py
@@ -224,14 +224,21 @@ class HidGuardian:
 
         # Process each entry to extract vendor and product id
         device_data = []
-        split_regex = re.compile("HID\\\\VID_([a-zA-Z0-9]+)&PID_([a-zA-Z0-9]+)")
+        split_regex = re.compile("HID\\\\VID_(.{4})&PID_(.{4})")
         for entry in data[0]:
             match = split_regex.match(entry)
             if match:
-                device_data.append((
-                    int(match.group(1), 16),
-                    int(match.group(2), 16)
-                ))
+                try:
+                    device_data.append((
+                        int(match.group(1), 16),
+                        int(match.group(2), 16)
+                    ))
+                except ValueError:
+                    gremlin.util.display_error(
+                        "Failed to extract vendor and product id for HidGuardian entry:\n\n{}"
+                            .format(entry)
+                    )
+
 
         return device_data
 

--- a/gremlin/hid_guardian.py
+++ b/gremlin/hid_guardian.py
@@ -224,7 +224,7 @@ class HidGuardian:
 
         # Process each entry to extract vendor and product id
         device_data = []
-        split_regex = re.compile("HID\\\\VID_(.+)&PID_(.+)")
+        split_regex = re.compile("HID\\\\VID_([a-zA-Z0-9]+)&PID_([a-zA-Z0-9]+)")
         for entry in data[0]:
             match = split_regex.match(entry)
             if match:


### PR DESCRIPTION
This pull request solves the issue #183 .
I am not capturing the serial number as it seems like it's not necessary, but if it was, this code could do that:
`split_regex = re.compile("HID\\\\VID_([a-zA-Z0-9]+)&PID_([a-zA-Z0-9]+)(?:&REV_([a-zA-Z0-9]+))?")`

Honored to do the first pull request! I really like your app after trying every other similar one like UCR, Freepie, Glovepie... and I have several years of experience with Python. So I would be happy to help with some other issues if you want