### PR TITLE
Added feature: keep last automatically loaded profile active

### DIFF
--- a/deploy.bat
+++ b/deploy.bat
@@ -1,15 +1,14 @@
-echo "Starting to build Gremlin ..."
-C:
-cd C:\Users\Ivan\PycharmProjects\JoystickGremlin
+@echo "Starting to build Gremlin ..."
+cd /d %0\..
 
-echo "Building executable ..."
+@echo "Building executable ..."
 pyinstaller -y --clean joystick_gremlin.spec
 
-echo "Generating WIX ..."
+@echo "Generating WIX ..."
 python generate_wix.py
 copy /Y joystick_gremlin.wxs dist\joystick_gremlin.wxs
 
-echo "Building MSI installer ..."
+@echo "Building MSI installer ..."
 cd dist
 del /Q PFiles
 del joystick_gremlin.wixobj

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -289,6 +289,31 @@ class Configuration:
             self.save()
 
     @property
+    def keep_last_autoload(self):
+        """Returns whether or not to keep last autoloaded profile active when it would otherwise
+        be automatically disabled.
+
+        This setting prevents unloading an autoloaded profile when not changing to another one.
+
+        :return True if last profile keeping is active, False otherwise
+        """
+        return self._data.get("keep_last_autoload", False)
+
+    @keep_last_autoload.setter
+    def keep_last_autoload(self, value):
+        """Sets whether or not to keep last autoloaded profile active when it would otherwise
+        be automatically disabled.
+
+        This setting prevents unloading an autoloaded profile when not changing to another one.
+
+        :param value Flag indicating whether or not to enable / disable the
+            feature
+        """
+        if type(value) == bool:
+            self._data["keep_last_autoload"] = value
+            self.save()
+
+    @property
     def highlight_input(self):
         """Returns whether or not to highlight inputs.
 

--- a/gremlin/ui/dialogs.py
+++ b/gremlin/ui/dialogs.py
@@ -186,10 +186,15 @@ class OptionsUi(common.BaseDialogUi):
         self.autoload_checkbox.setChecked(self.config.autoload_profiles)
 
         self.keep_last_autoload_checkbox = QtWidgets.QCheckBox(
-            "Keep last automatically loaded profile active when its application loses focus"
+            "Keep profile active on focus loss"
         )
+        self.keep_last_autoload_checkbox.setToolTip("""If this option is off, profiles that have been configured to load automatically when an application gains focus
+will deactivate when that application loses focus.
+
+If this option is on, the last active profile will remain active until a different profile is loaded.""")
         self.keep_last_autoload_checkbox.clicked.connect(self._keep_last_autoload)
         self.keep_last_autoload_checkbox.setChecked(self.config.keep_last_autoload)
+        self.keep_last_autoload_checkbox.setEnabled(self.config.autoload_profiles)
 
         # Executable dropdown list
         self.executable_layout = QtWidgets.QHBoxLayout()
@@ -344,6 +349,7 @@ class OptionsUi(common.BaseDialogUi):
 
         :param clicked whether or not the checkbox is ticked
         """
+        self.keep_last_autoload_checkbox.setEnabled(clicked)
         self.config.autoload_profiles = clicked
         self.config.save()
 

--- a/gremlin/ui/dialogs.py
+++ b/gremlin/ui/dialogs.py
@@ -185,6 +185,12 @@ class OptionsUi(common.BaseDialogUi):
         self.autoload_checkbox.clicked.connect(self._autoload_profiles)
         self.autoload_checkbox.setChecked(self.config.autoload_profiles)
 
+        self.keep_last_autoload_checkbox = QtWidgets.QCheckBox(
+            "Keep last automatically loaded profile active when its application loses focus"
+        )
+        self.keep_last_autoload_checkbox.clicked.connect(self._keep_last_autoload)
+        self.keep_last_autoload_checkbox.setChecked(self.config.keep_last_autoload)
+
         # Executable dropdown list
         self.executable_layout = QtWidgets.QHBoxLayout()
         self.executable_label = QtWidgets.QLabel("Executable")
@@ -226,6 +232,7 @@ class OptionsUi(common.BaseDialogUi):
         self.profile_layout.addWidget(self.profile_select)
 
         self.profile_page_layout.addWidget(self.autoload_checkbox)
+        self.profile_page_layout.addWidget(self.keep_last_autoload_checkbox)
         self.profile_page_layout.addLayout(self.executable_layout)
         self.profile_page_layout.addLayout(self.profile_layout)
         self.profile_page_layout.addStretch()
@@ -338,6 +345,14 @@ class OptionsUi(common.BaseDialogUi):
         :param clicked whether or not the checkbox is ticked
         """
         self.config.autoload_profiles = clicked
+        self.config.save()
+
+    def _keep_last_autoload(self, clicked):
+        """Stores keep last autoload preference.
+
+        :param clicked whether or not the checkbox is ticked
+        """
+        self.config.keep_last_autoload = clicked
         self.config.save()
 
     def _activate_on_launch(self, clicked):

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -813,8 +813,9 @@ class GremlinUi(QtWidgets.QMainWindow):
         """Handles changes in the active process.
 
         If the active process has a known associated profile it is
-        loaded and activated if none exists the application is
-        disabled.
+        loaded and activated. If none exists and the user has not
+        enabled the option to keep the last profile active, the current
+        profile is disabled,
 
         :param path the path to the currently active process executable
         """
@@ -827,7 +828,7 @@ class GremlinUi(QtWidgets.QMainWindow):
             self.ui.actionActivate.setChecked(True)
             self.activate(True)
             self._profile_auto_activated = True
-        elif self._profile_auto_activated:
+        elif self._profile_auto_activated and not self.config.keep_last_autoload:
             self.ui.actionActivate.setChecked(False)
             self.activate(False)
             self._profile_auto_activated = False


### PR DESCRIPTION
Added a checkbox in the options that allows the user to choose to keep the last automatically loaded profile active when its application loses focus. This is something I need because disabling the profile causes my throttle and pedal axes to revert to centre when the profile disables, and I often tab out of Star Citizen to briefly chat on another monitor, etc.

I would consider this an adequate fix for the issue I raised, #279.