### PR TITLE
Fixes macros recording a pause of 0 seconds before first axis input

### DIFF
--- a/action_plugins/macro/__init__.py
+++ b/action_plugins/macro/__init__.py
@@ -1349,13 +1349,12 @@ class MacroWidget(gremlin.ui.input_item.AbstractActionWidget):
             cur_index = self.list_view.currentIndex().row()
             entry = self.model.get_entry(cur_index)
 
-            if event not in self._recording_times:
-                self._recording_times[event] = time.time()
-            elif time.time() - self._recording_times[event] < self._polling_rate:
-                add_new_entry = False
-            elif abs(event.value - self._recording_values[event]) < \
-                    self._minimum_change_amount:
-                add_new_entry = False
+            if event in self._recording_times:
+                if time.time() - self._recording_times[event] < self._polling_rate:
+                    add_new_entry = False
+                elif abs(event.value - self._recording_values[event]) < \
+                        self._minimum_change_amount:
+                    add_new_entry = False
 
         if add_new_entry:
             if self.record_time.isChecked():


### PR DESCRIPTION
I was using Joystick Gremlin to record a macro with a throttle and stick and noticed that the time between the throttle being maxed out and the joystick being moved was not recorded. The first input event for each axis always had a pause of 0 seconds before it and ignored any wait between a previous action and moving the joystick, so I figured I would take a look into the code to see why.

This issue was caused by the behavior when checking if a new JoystickAction should be created. Before recording the action, there are checks to see if the event is outside the polling rate and minimum change amount allowed, but before these checks there is a null check that confirms the event (or more accurately an earlier event with the same hash value) is already in the _recording_times dictionary. If the event is not in the dictionary then an entry is added for this new event and the time for the entry is set to now; this behavior is incorrect because it sabotages the creation of the PauseAction in the next if statement block. The PauseAction created will record the time between now and the last action recorded in the dictionary, which was just added now so there is a zero second pause recorded between the "last" event and this new one because they are the same event.

Adding the new event to the _recording_times dictionary is not even necessary at this step because if the "if event not in self._recording_times" case is true then the "if add_new_entry" will always execute and that code block does the same operation to add the event to _recording_times. Because adding the event to _recording_times will be done later, I have rearranged the if statements such that if the event IS in _recording_times then the checks for polling rate and minimum change will be performed, but if the event is not in _recording_times then we skip the check because this is the very first event from that device and input identifier so there is no need and no way to check the event against the polling rate and minimum change amount.

Might have overdone it on this explanation for a small fix, but I figured more info is better than less. Thanks for the great tool.