### PR TITLE
Map to Keyboard Tweak

### DIFF
--- a/action_plugins/map_to_keyboard/__init__.py
+++ b/action_plugins/map_to_keyboard/__init__.py
@@ -105,7 +105,8 @@ class MapToKeyboardFunctor(AbstractFunctor):
             self.press.press(gremlin.macro.key_from_code(key[0], key[1]))
 
         self.release = gremlin.macro.Macro()
-        for key in action.keys:
+        # Execute release in reverse order
+        for key in reversed(action.keys):
             self.release.release(gremlin.macro.key_from_code(key[0], key[1]))
 
     def process_event(self, event, value):


### PR DESCRIPTION
Hello, I've been having a few issues using `Map to Keyboard` feature in IL2 due to what I think is caused by the release commands happening in the same order as they are pressed.

This creates issues when, for example binding flaps that depend on `F` to lower flaps and `LShift+F` to raise flaps. The Raise Flaps command ends up undoing itself due to the split second timing of `F` still being pressed when `LShift` is released.

Looking at the code, I was wondering if simply executing the release macro in reverse order would be a safe and quick way to fix this problem? (which as you can see is essentially what I did in this PR).

Unfortunately my Windows machine is not setup for development, so I was unable to test, and I also know jack shit about how Joystick Gremlin works under the hood, so there's a greater than 0 chance this won't work for other reasons that I may not fathom.

And if it is a valid fix, then the least I can do is help it along.