### PR TITLE
Added scroll bar to the user plugin variable list.

### DIFF
--- a/gremlin/ui/user_plugin_management.py
+++ b/gremlin/ui/user_plugin_management.py
@@ -107,6 +107,7 @@ class ModuleManagementController(QtCore.QObject):
 
         layout = self.view.right_panel.layout()
         gremlin.ui.common.clear_layout(layout)
+        self.scroll_layout = QtWidgets.QVBoxLayout()
         for var in variables:
             if type(var) in [
                 gremlin.user_plugin.BoolVariable,
@@ -143,7 +144,7 @@ class ModuleManagementController(QtCore.QObject):
                         self._update_value_variable
                     )
                 )
-                layout.addLayout(ui_element)
+                self.scroll_layout.addLayout(ui_element)
             else:
                 logging.getLogger("system").error(
                     "Invalid variable type encountered in user "
@@ -152,8 +153,15 @@ class ModuleManagementController(QtCore.QObject):
                         var.label
                     )
                 )
-                layout.addWidget(QtWidgets.QLabel(var.label))
-        layout.addStretch()
+                self.scroll_layout.addWidget(QtWidgets.QLabel(var.label))
+        self.scroll_area = QtWidgets.QScrollArea()
+        self.scroll_widget = QtWidgets.QWidget()
+        self.scroll_widget.setLayout(self.scroll_layout)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setWidget(self.scroll_widget)
+        self.scroll_area.setHorizontalScrollBarPolicy(1)
+        self.scroll_area.setMinimumWidth(self.scroll_layout.minimumSize().width() + 19)
+        layout.addWidget(self.scroll_area)
 
     def _update_value_variable(self, data, widget, variable):
         if variable.type in [


### PR DESCRIPTION
I am currently working on a user plugin that has gotten a bit out of hand. It has so many input and other variables that the list doesn't fit on my screen any longer. The only way to access the lower parts (apart from editing the xml file manually) was to maximize the window which squishes the list vertically but then the individual variables were barely readable. That's why I added a scroll bar to that list.