### PR TITLE
Fix vjoy activation condition handling

### DIFF
--- a/gremlin/ui/activation_condition.py
+++ b/gremlin/ui/activation_condition.py
@@ -624,12 +624,38 @@ class VJoyConditionWidget(AbstractConditionWidget):
         self.condition_data.vjoy_id = data["device_id"]
         self.condition_data.input_type = data["input_type"]
         self.condition_data.input_id = data["input_id"]
+        
+        valid_axis_condition = [
+            "inside",
+            "outside"
+            ]
+        valid_button_condition = [
+            "pressed",
+            "released"
+            ]
+        valid_hat_condition = [
+            "center",
+            "north",
+            "north-east",
+            "east",
+            "south-east",
+            "south",
+            "south-west",
+            "west",
+            "north-west"
+            ]
 
-        if data["input_type"] == InputType.JoystickAxis:
+        if (data["input_type"] == InputType.JoystickAxis and
+            self.condition_data.comparison not in valid_axis_condition
+           ):
             self.condition_data.comparison = "inside"
-        elif data["input_type"] == InputType.JoystickButton:
+        elif (data["input_type"] == InputType.JoystickButton and
+              self.condition_data.comparison not in valid_button_condition
+             ):
             self.condition_data.comparison = "pressed"
-        elif data["input_type"] == InputType.JoystickHat:
+        elif (data["input_type"] == InputType.JoystickHat and
+              self.condition_data.comparison not in valid_hat_condition
+             ):
             self.condition_data.comparison = \
                 util.hat_tuple_to_direction((0, 0))
         self._create_ui()


### PR DESCRIPTION
This has come up in the discord a couple of times (and mentioned here as well #361). Decided to take a look myself to fix the issue. This fixed the problem on my end. Happy to provide a compiled win x64 binary if that is of use too.

Here are the changes from the commit itself:

Previously all vjoy activation conditions would be reset to the default value when the UI was refreshed. This was due to several lines in `VJoyConditionWidget._modify_vjoy` which were intended to reset to a default value if the VJoy input was modified. Unfortunately, `_modify_vjoy` is called every time the UI is reset, thus resetting the condition trigger in addition to the intended
effect of updating the selected VJoy input.

To avoid the reset, we simply removed the lines that change the activation condition within `_modify_vjoy`.