### PR TITLE
Added Clipboard implementation

### DIFF
--- a/gremlin/clipboard.py
+++ b/gremlin/clipboard.py
@@ -15,30 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gremlin.actions
-import gremlin.base_classes
-import gremlin.cheatsheet
-import gremlin.code_runner
-import gremlin.common
-import gremlin.config
-import gremlin.control_action
-import gremlin.error
-import gremlin.event_handler
-import gremlin.execution_graph
-import gremlin.fsm
-import gremlin.hid_guardian
-import gremlin.hints
-import gremlin.input_devices
-import gremlin.joystick_handling
-import gremlin.macro
-import gremlin.plugin_manager
-import gremlin.process_monitor
-import gremlin.profile
-import gremlin.repeater
-import gremlin.shared_state
-import gremlin.sendinput
-import gremlin.spline
-import gremlin.tts
-import gremlin.util
-import gremlin.windows_event_hook
-import gremlin.clipboard
+from . import common
+
+
+@common.SingletonDecorator
+class Clipboard:
+
+    """Responsible for storing and restoring action related data."""
+
+    def __init__(self):
+        """Creates a new instance, initializing empty clipboard."""
+        self.item_data = None
+
+    def copy(self, item_data):
+        """ Saves item_data to clipboard """
+        self.item_data = item_data
+
+    def paste(self):
+        """ Returns item_data saved in clipboard """
+        return self.item_data
+

--- a/gremlin/ui/device_tab.py
+++ b/gremlin/ui/device_tab.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore, QtGui
 
 import container_plugins.basic
 import gremlin
@@ -35,7 +35,7 @@ class InputItemConfiguration(QtWidgets.QFrame):
     # Signal emitted when the description changes
     description_changed = QtCore.pyqtSignal(str)
 
-    def __init__(self, item_data, parent=None):
+    def __init__(self, item_data, parent=None, clipboard=None):
         """Creates a new object instance.
 
         :param item_data profile data associated with the item
@@ -61,6 +61,21 @@ class InputItemConfiguration(QtWidgets.QFrame):
         self.action_view.redraw()
 
         self.main_layout.addWidget(self.action_view)
+
+        self.clipboard = clipboard
+        self.copy_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence('Ctrl+C'), self)
+        self.copy_shortcut.activated.connect(self._copy_actions)
+        self.paste_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence('Ctrl+V'), self)
+        self.paste_shortcut.activated.connect(self._paste_actions)
+
+    def update_item_data(self, item_data):
+        # delete old data containers, add new ones
+        for container_id in reversed(range(0, self.action_model.rows())):
+            container_data = self.action_model.data(container_id)
+            self.action_model.remove_container(container_data)
+        for container in item_data.containers:
+            self.action_model.add_container(container)
+        self.item_data = item_data
 
     def _add_action(self, action_name):
         """Adds a new action to the input item.
@@ -185,6 +200,15 @@ class InputItemConfiguration(QtWidgets.QFrame):
                     action_names.append(entry.name)
         return sorted(action_names)
 
+    def _copy_actions(self):
+        """ Copies current actions and makes them available for pasting """
+        self.clipboard.copy(self.item_data)
+
+    def _paste_actions(self):
+        """ Pastes copied actions into currently selected item """
+        data = self.clipboard.paste()
+        if data and data is not self.item_data:
+            self.update_item_data(data)
 
 class ActionContainerModel(common.AbstractModel):
 
@@ -296,7 +320,8 @@ class JoystickDeviceTabWidget(QtWidgets.QWidget):
             device,
             device_profile,
             current_mode,
-            parent=None
+            parent=None,
+            clipboard = None
     ):
         """Creates a new object instance.
 
@@ -371,6 +396,7 @@ class JoystickDeviceTabWidget(QtWidgets.QWidget):
             self.left_panel_layout.addWidget(label)
 
         self.main_layout.addLayout(self.left_panel_layout)
+        self.clipboard = clipboard
 
     def input_item_selected_cb(self, index):
         """Handles the selection of an input item.
@@ -390,7 +416,7 @@ class JoystickDeviceTabWidget(QtWidgets.QWidget):
         self.main_layout.removeItem(item)
 
         if item_data is not None:
-            widget = InputItemConfiguration(item_data)
+            widget = InputItemConfiguration(item_data, clipboard=self.clipboard)
             change_cb = self._create_change_cb(index)
             widget.action_model.data_changed.connect(change_cb)
             widget.description_changed.connect(change_cb)

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -100,6 +100,8 @@ class GremlinUi(QtWidgets.QMainWindow):
         self._profile = gremlin.profile.Profile()
         self._profile_fname = None
         self._profile_auto_activated = False
+        self.clipboard = gremlin.clipboard.Clipboard()
+
         # Input selection storage
         self._last_input_timestamp = time.time()
         self._last_input_event = None
@@ -606,7 +608,8 @@ class GremlinUi(QtWidgets.QMainWindow):
             widget = gremlin.ui.device_tab.JoystickDeviceTabWidget(
                 device,
                 device_profile,
-                self._current_mode
+                self._current_mode,
+                clipboard = self.clipboard
             )
             self.tabs[device.device_guid] = widget
             tab_label = device.name.strip()
@@ -627,7 +630,8 @@ class GremlinUi(QtWidgets.QMainWindow):
             widget = gremlin.ui.device_tab.JoystickDeviceTabWidget(
                 device,
                 device_profile,
-                self._current_mode
+                self._current_mode,
+                clipboard = self.clipboard
             )
             self.tabs[device.device_guid] = widget
             tab_label = device.name.strip()
@@ -662,7 +666,8 @@ class GremlinUi(QtWidgets.QMainWindow):
             widget = gremlin.ui.device_tab.JoystickDeviceTabWidget(
                 device,
                 device_profile,
-                self._current_mode
+                self._current_mode,
+                clipboard = self.clipboard
             )
             self.tabs[device.device_guid] = widget
             self.ui.devices.addTab(


### PR DESCRIPTION
* Supports copy/pasting actions from one button to another.

Please consider such functionality (if not already) for r14. Feedback is welcome (NOTE: I don't consider myself a Qt developer at all, so I might have done things at wrong places).

The feature is very much useful when moving things around. I have more ideas on right-clicking the button and giving a user ability to:
- move actions to another mode
- copy actions from another mode
- copy actions to another mode

But all of these could use Clipboard to get stuff done.