### PR TITLE
PR 571: fix for horizontal scrolling of device list area

### DIFF
--- a/qml/DeviceList.qml
+++ b/qml/DeviceList.qml
@@ -46,8 +46,8 @@ Item {
         delegate: _deviceDelegate
 
         // Make it behave like a sensible scrolling container
-        ScrollBar.vertical: ScrollBar {}
-        flickableDirection: Flickable.VerticalFlick
+        ScrollBar.horizontal: ScrollBar {}
+        flickableDirection: Flickable.HorizontalFlick
         boundsBehavior: Flickable.StopAtBounds
     }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -389,7 +389,6 @@ ApplicationWindow {
                 }
 
                 MouseArea {
-                    anchors.fill: parent
                     propagateComposedEvents: true
                     onClicked: function(mouse)
                     {


### PR DESCRIPTION
Adding links for inspiration about potential future UI changes around Intermediate Ouput:
- height, anchors: https://stackoverflow.com/questions/28503715/why-does-adding-a-mousearea-with-anchors-fill-parent-cause-the-rows-to-stack-up
- signals & properties - https://doc.qt.io/qt-6/qtqml-syntax-signals.html & https://doc.qt.io/qt-6/qtqml-syntax-objectattributes.html