### PR TITLE
Bugfixes/moza r12 unprintable x90 in name causes crash

### DIFF
--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -398,7 +398,10 @@ class DeviceSummary:
         self.vendor_id = data.vendor_id
         self.product_id = data.product_id
         self.joystick_id = data.joystick_id
-        self.name = data.name.decode("utf-8")
+        # Some manufacturers seem to have tighter tolerances for what they supply for name. The Moza R12 seems to
+        # have an issue where it outputs some garbage bytes. This fix requires the name is escaped consistently after
+        # entering Gremlin.
+        self.name = data.name.decode("utf-8", errors="ignore")
         self.axis_count = data.axis_count
         self.button_count = data.button_count
         self.hat_count = data.hat_count

--- a/test/test_dill.py
+++ b/test/test_dill.py
@@ -1,0 +1,9 @@
+from dill import _DeviceSummary, DeviceSummary
+
+
+def test_DeviceSummary_initialisation():
+    c_device_summary = _DeviceSummary()
+    c_device_summary.name = b'MOZA R12 Base\x90'
+    device_summary = DeviceSummary(data=c_device_summary)
+
+    assert device_summary.name == "MOZA R12 Base"


### PR DESCRIPTION
**Bug:**
The Moza r12 steering wheel base seems to output a non-UTF8 character 0x90, causing decoding to throw, and crashing the program. I believe this comes from the device, and not any stack in Gremlin, as other devices report their names as expected.

![Screenshot 2025-02-16 190754](https://github.com/user-attachments/assets/deab1544-c469-4ebe-83de-dd0c60a94a32)


**Fix:**
Make the decoding ignore invalid characters. The alternative fix would have been to replace 0x90 with an unprintable <?> character, but I don't think there's any reason for that, and it looks ugly.

I am not aware of any risk in this fix. Names with only valid characters will be unaffected.

There's a slight chance that if there's multiple routes names could be read from the USB device, this could introduce an inconsistency (for names with illegal chars only), and a potential mismatch, if the name (and not ID) was used to equate two devices.

**Testing:**
1. Added debug statements, printing `_DeviceSummary.name` just before the line
2. Saw it crash before change was made
3. After change, correctly enumerated devices
![image](https://github.com/user-attachments/assets/b709da36-464f-402d-9331-895ad45cc438)
4. Saw Moza R12 axis values update in Gremlin "Input Viewer"
5. Added a mapping to vjoy, saw vjoy update appropriately
![image](https://github.com/user-attachments/assets/32d646d6-d676-487c-aedc-0a582eda4e0a)


I have also added a unit test - would appreciate feedback if there's anything else I need to do in that area.