### PR TITLE
Github action to create nightly builds

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -27,12 +27,11 @@ jobs:
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "DATE=$(date +'%Y_%m_%d)" >> $GITHUB_STATE
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_${{ steps.date.outputs.date }}
+        name: joystick_gremlin_nightly_${{ GITHUB_STATE.DATE }}
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -31,11 +31,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pyinstaller
     - name: Build executable
-      run: python -m PyInstaller joystick_gremlin.spec -y --clean
-      #pyinstaller -y --clean joystick_gremlin.spec
-      working-directory: ./
+      #run: python -m PyInstaller joystick_gremlin.spec -y --clean
+      run: pyinstaller -y --clean joystick_gremlin.spec
+      #working-directory: ./
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -26,10 +26,13 @@ jobs:
       run: poetry install
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly
+        name: joystick_gremlin_nightly_${{ steps.date.outputs.date }}
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -19,19 +19,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up poetry for dependency management
-      uses: abatilo/actions-poetry@v3
+      uses: abatilo/actions-poetry@v2
       with:
         poetry-version: ${{ matrix.poetry-version }}
     - name: Setup a local virtual environment
       run: |
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
+    - uses: actions/cache@v3
+      name: Setup a cache
+      with:
+        path: ./.venv
+        key: venv-${{ hashFiles('poetry.lock') }}
     - name: Install the project dependencies with poetry
       run: poetry install
     - name: Install dependencies
-      run: pipx install pyinstaller
-    #     python -m pip install --upgrade pip
-        # pipx install pyinstaller
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller
     - name: Build executable
       run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -12,6 +12,8 @@ jobs:
       matrix:
         python-version: ["3.12"]
         poetry-version: ["latest"]
+    env:
+      DATE: $(date +'%Y_%m_%d')
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,12 +28,12 @@ jobs:
       run: poetry install
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
-    - name: Get current date
-      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
+    # - name: Get current date
+    #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: "joystick_gremlin_nightly_$CURRENT_DATE"
+        name: joystick_gremlin_nightly_${{ env.DATE }}
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -32,9 +32,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+    #- name: Build executable
+    #  run: pyinstaller -y --clean joystick_gremlin.spec
+    #  working-directory: ./
     - name: Build executable
-      run: pyinstaller -y --clean joystick_gremlin.spec
-      working-directory: ./
+      uses: JackMcKew/pyinstaller-action-windows@main
+      with:
+        path: ./
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,9 +28,6 @@ jobs:
       run: poetry install
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
-    # - name: Store current date
-    #   id: current_date
-    #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> "$GITHUB_OUTPUT"
     - name: Store current date
       run: |
         $CURRENT_DATE=& Get-Date -format yyyy_MM_dd
@@ -48,16 +45,16 @@ jobs:
         if-no-files-found: warn
         retention-days: 7
         overwrite: true
-    - name: Download build
-      uses: actions/download-artifact@v4
-      with:
-        name: joystick_gremlin_nightly
-        path: /tmp/
-    - name: Display structure of downloaded files
-      run: ls /tmp
-    - name: Compress the build again
+    # - name: Download build
+    #   uses: actions/download-artifact@v4
+    #   with:
+    #     name: joystick_gremlin_nightly
+    #     path: /tmp/
+    # - name: Display structure of downloaded files
+    #   run: ls /tmp
+    - name: Compress the build
       run: |
-        Compress-Archive -Path /tmp/joystick_gremlin/* -DestinationPath /tmp/joystick_gremlin_nightly.zip
+        Compress-Archive -Path /dist/* -DestinationPath /tmp/joystick_gremlin_nightly.zip
       shell: pwsh
     - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,14 +28,12 @@ jobs:
           poetry config virtualenvs.in-project true --local
     - name: Install the project dependencies with poetry
       run: poetry install
-    # - name: Install dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install pyinstaller
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller, pyside6
     - name: Build executable
-      #run: python -m PyInstaller joystick_gremlin.spec -y --clean
       run: pyinstaller -y --clean joystick_gremlin.spec
-      #working-directory: ./
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -54,11 +54,11 @@ jobs:
     #   run: ls /tmp
     - name: Compress the build
       run: |
-        Compress-Archive -Path /dist/* -DestinationPath /tmp/joystick_gremlin_nightly.zip
+        Compress-Archive -Path dist/* -DestinationPath dist/joystick_gremlin_nightly.zip
       shell: pwsh
     - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: /tmp/joystick_gremlin_nightly.zip
+        files: dist/joystick_gremlin_nightly.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_$CURRENT_DATE
+        name: "joystick_gremlin_nightly_$CURRENT_DATE"
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "nightly-build-action"
+  # schedule:
+  #   - cron: '45 23 * * *' # runs daily at 23:45
 
 jobs:
   build:
@@ -28,17 +30,13 @@ jobs:
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     # - name: Get current date
     #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
-    - name: Set date
-      run: |
-        DATE=$(date +'%Y_%m_%d')
-        echo "DATE=$DATE" >> $GITHUB_ENV
-    - name: Echo Date
-      run: |
-        echo "The date this run was created was $DATE"
+    - name: Store current date
+      id: current_date
+      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> "$GITHUB_OUTPUT"
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_$DATE
+        name: joystick_gremlin_nightly_${{ steps.current_date.outputs.CURRENT_DATE }}
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -6,9 +6,6 @@ on:
       - "nightly-build-action"
 
 jobs:
-  defaults:
-    run:
-      shell: bash
   build:
     runs-on: windows-latest
     strategy:
@@ -22,7 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up poetry for dependency management
-      uses: abatilo/actions-poetry@v2
+      uses: abatilo/actions-poetry@v3
       with:
         poetry-version: ${{ matrix.poetry-version }}
     - name: Setup a local virtual environment

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,6 +51,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
+        name: joystick_gremlin_nightly
         path: /tmp/
     - name: Upload to Nightly release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -56,5 +56,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: /tmp/joystick_gremlin_nightly.zip
+        files: /tmp/
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pyinstaller
+        pip install PySide6
     - name: Build executable
       run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -47,5 +47,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: dist/joystick_gremlin_nightly.zip
+        files: dist/
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,10 +28,10 @@ jobs:
           poetry config virtualenvs.in-project true --local
     - name: Install the project dependencies with poetry
       run: poetry install
-    # - name: Install dependencies
-    #   run: |
+    - name: Install dependencies
+      run: |
     #     python -m pip install --upgrade pip
-    #     pip install pyinstaller, pyside6
+        pipx install pyinstaller
     - name: Build executable
       run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,11 +1,11 @@
 name: NightlyBuild
 
 on:
-  push:
-    branches:
-      - "nightly-build-action"
-  # schedule:
-  #   - cron: '45 23 * * *' # runs daily at 23:45
+  # push:
+  #   branches:
+  #     - "nightly-build-action"
+  schedule:
+    - cron: '45 23 * * *' # runs daily at 23:45
 
 jobs:
   build:
@@ -35,14 +35,6 @@ jobs:
     - name: Echo current date
       run: |
         echo "${{env.CURRENT_DATE}}"
-    # - name: Upload build}
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: joystick_gremlin_nightly
-    #     path: dist/
-    #     if-no-files-found: warn
-    #     retention-days: 7
-    #     overwrite: true
     - name: Compress the build
       run: |
         Compress-Archive -Path dist/* -DestinationPath dist/joystick_gremlin_nightly_${{env.CURRENT_DATE}}.zip

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -6,6 +6,9 @@ on:
       - "nightly-build-action"
 
 jobs:
+  defaults:
+    run:
+      shell: bash
   build:
     runs-on: windows-latest
     strategy:
@@ -28,12 +31,14 @@ jobs:
           poetry config virtualenvs.in-project true --local
     - name: Install the project dependencies with poetry
       run: poetry install
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pyinstaller, pyside6
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install pyinstaller, pyside6
     - name: Build executable
-      run: pyinstaller -y --clean joystick_gremlin.spec
+      run: |
+        source $VENV
+        pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -52,5 +52,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: joystick_gremlin_nightly.zip
+        files: joystick_gremlin_nightly
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -35,23 +35,14 @@ jobs:
     - name: Echo current date
       run: |
         echo "${{env.CURRENT_DATE}}"
-    - name: Upload build
-      # env:
-      #   CURRENT_DATE: ${{ steps.current_date.outputs.CURRENT_DATE }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: joystick_gremlin_nightly
-        path: dist/
-        if-no-files-found: warn
-        retention-days: 7
-        overwrite: true
-    # - name: Download build
-    #   uses: actions/download-artifact@v4
+    # - name: Upload build}
+    #   uses: actions/upload-artifact@v4
     #   with:
     #     name: joystick_gremlin_nightly
-    #     path: /tmp/
-    # - name: Display structure of downloaded files
-    #   run: ls /tmp
+    #     path: dist/
+    #     if-no-files-found: warn
+    #     retention-days: 7
+    #     overwrite: true
     - name: Compress the build
       run: |
         Compress-Archive -Path dist/* -DestinationPath dist/joystick_gremlin_nightly_${{env.CURRENT_DATE}}.zip

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,10 +28,10 @@ jobs:
           poetry config virtualenvs.in-project true --local
     - name: Install the project dependencies with poetry
       run: poetry install
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pyinstaller
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install pyinstaller
     - name: Build executable
       #run: python -m PyInstaller joystick_gremlin.spec -y --clean
       run: pyinstaller -y --clean joystick_gremlin.spec

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,42 @@
+name: NightlyBuild
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        poetry-version: ["latest"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up poetry for dependency management
+      uses: abatilo/actions-poetry@v2
+      with:
+        poetry-version: ${{ matrix.poetry-version }}
+    - name: Setup a local virtual environment
+      run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+    - name: Install the project dependencies with poetry
+      run: poetry install
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Build executable
+      run: pyinstaller -y --clean joystick_gremlin.spec
+      working-directory: ./
+    - name: Upload build
+      uses: actions/upload-artifact@v4
+      with:
+        name: joystick_gremlin_nightly
+        path: dist/
+        if-no-files-found: warn
+        retention-days: 7
+        overwrite: true

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -54,10 +54,12 @@ jobs:
         name: joystick_gremlin_nightly.zip
         path: /tmp/
     - name: Display structure of downloaded files
-      run: ls -R /tmp
+      run: ls /tmp
+    - name: Zip build up again
+      run: zip -r /tmp/joystick_gremlin_nightly.zip /tmp/joystick_gremlin/
     - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: /tmp/joystick_gremlin_nightly
+        files: /tmp/joystick_gremlin_nightly.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     - name: Get current date
-      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d)" >> $GITHUB_ENV
+      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -55,8 +55,10 @@ jobs:
         path: /tmp/
     - name: Display structure of downloaded files
       run: ls /tmp
-    - name: Zip build up again
-      run: zip -r /tmp/joystick_gremlin_nightly.zip /tmp/joystick_gremlin/
+    - name: Compress the build again
+      run: |
+        Compress-Archive -Path /tmp/joystick_gremlin/* -DestinationPath /tmp/joystick_gremlin_nightly.zip
+      shell: pwsh
     - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,10 +51,10 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
-        path: ./
+        path: /tmp/
     - name: Upload to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: ./joystick_gremlin_nightly.zip
+        files: /tmp/joystick_gremlin_nightly.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Download build
       uses: actions/download-artifact@v4
       with:
-        name: joystick_gremlin_nightly
+        name: joystick_gremlin_nightly.zip
         path: /tmp/
     - name: Display structure of downloaded files
       run: ls -R /tmp

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,22 +22,8 @@ jobs:
       uses: abatilo/actions-poetry@v2
       with:
         poetry-version: ${{ matrix.poetry-version }}
-    # - name: Setup a local virtual environment
-    #   run: |
-    #       poetry config virtualenvs.create true --local
-    #       poetry config virtualenvs.in-project true --local
-    # - uses: actions/cache@v3
-    #   name: Setup a cache
-    #   with:
-    #     path: ./.venv
-    #     key: venv-${{ hashFiles('poetry.lock') }}
     - name: Install the project dependencies with poetry
       run: poetry install
-    # - name: Install dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install pyinstaller
-    #     pip install PySide6
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -48,14 +48,16 @@ jobs:
         if-no-files-found: warn
         retention-days: 7
         overwrite: true
-    - name: Download artifact
+    - name: Download build
       uses: actions/download-artifact@v4
       with:
         name: joystick_gremlin_nightly
         path: /tmp/
-    - name: Upload to Nightly release
+    - name: Display structure of downloaded files
+      run: ls -R /tmp
+    - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: /tmp/*
+        files: /tmp/joystick_gremlin_nightly
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -56,5 +56,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: /tmp/
+        files: /tmp/*
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -26,11 +26,11 @@ jobs:
       run: |
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
-    - uses: actions/cache@v3
-      name: Setup a cache
-      with:
-        path: ./.venv
-        key: venv-${{ hashFiles('poetry.lock') }}
+    # - uses: actions/cache@v3
+    #   name: Setup a cache
+    #   with:
+    #     path: ./.venv
+    #     key: venv-${{ hashFiles('poetry.lock') }}
     - name: Install the project dependencies with poetry
       run: poetry install
     - name: Install dependencies

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,10 +22,10 @@ jobs:
       uses: abatilo/actions-poetry@v2
       with:
         poetry-version: ${{ matrix.poetry-version }}
-    - name: Setup a local virtual environment
-      run: |
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
+    # - name: Setup a local virtual environment
+    #   run: |
+    #       poetry config virtualenvs.create true --local
+    #       poetry config virtualenvs.in-project true --local
     # - uses: actions/cache@v3
     #   name: Setup a cache
     #   with:
@@ -33,11 +33,11 @@ jobs:
     #     key: venv-${{ hashFiles('poetry.lock') }}
     - name: Install the project dependencies with poetry
       run: poetry install
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pyinstaller
-        pip install PySide6
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install pyinstaller
+    #     pip install PySide6
     - name: Build executable
       run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,6 +1,9 @@
 name: NightlyBuild
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - "nightly-build-action"
 
 jobs:
   build:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -32,13 +32,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-    #- name: Build executable
-    #  run: pyinstaller -y --clean joystick_gremlin.spec
-    #  working-directory: ./
     - name: Build executable
-      uses: JackMcKew/pyinstaller-action-windows@main
-      with:
-        path: ./
+      run: python -m PyInstaller joystick_gremlin.spec -y --clean
+      #pyinstaller -y --clean joystick_gremlin.spec
+      working-directory: ./
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         python-version: ["3.12"]
         poetry-version: ["latest"]
-    env:
-      DATE: $(date +'%Y_%m_%d')
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,10 +28,17 @@ jobs:
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     # - name: Get current date
     #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
+    - name: Set date
+      run: |
+        DATE=$(date +'%Y_%m_%d')
+        echo "DATE=$DATE" >> $GITHUB_ENV
+    - name: Echo Date
+      run: |
+        echo "The date this run was created was $DATE"
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_${{ env.DATE }}
+        name: joystick_gremlin_nightly_$DATE
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,14 +28,19 @@ jobs:
       run: poetry install
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
-    # - name: Get current date
-    #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> $GITHUB_ENV
+    # - name: Store current date
+    #   id: current_date
+    #   run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> "$GITHUB_OUTPUT"
     - name: Store current date
-      id: current_date
-      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> "$GITHUB_OUTPUT"
+      run: |
+        $CURRENT_DATE=& Get-Date -format yyyy_MM_dd
+        echo "CURRENT_DATE=$CURRENT_DATE" >> $env:GITHUB_ENV
+    - name: Echo current date
+      run: |
+        echo "${{env.CURRENT_DATE}}"
     - name: Upload build
-      env:
-        CURRENT_DATE: ${{ steps.current_date.outputs.CURRENT_DATE }}
+      # env:
+      #   CURRENT_DATE: ${{ steps.current_date.outputs.CURRENT_DATE }}
       uses: actions/upload-artifact@v4
       with:
         name: joystick_gremlin_nightly
@@ -47,5 +52,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: dist/
+        files: joystick_gremlin_nightly.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Download build
       uses: actions/download-artifact@v4
       with:
-        name: joystick_gremlin_nightly.zip
+        name: joystick_gremlin_nightly
         path: /tmp/
     - name: Display structure of downloaded files
       run: ls /tmp

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -54,11 +54,11 @@ jobs:
     #   run: ls /tmp
     - name: Compress the build
       run: |
-        Compress-Archive -Path dist/* -DestinationPath dist/joystick_gremlin_nightly.zip
+        Compress-Archive -Path dist/* -DestinationPath dist/joystick_gremlin_nightly_${{env.CURRENT_DATE}}.zip
       shell: pwsh
     - name: Upload build to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: dist/joystick_gremlin_nightly.zip
+        files: dist/joystick_gremlin_nightly_${{env.CURRENT_DATE}}.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install the project dependencies with poetry
       run: poetry install
     - name: Install dependencies
-      run: |
+      run: pipx install pyinstaller
     #     python -m pip install --upgrade pip
-        pipx install pyinstaller
+        # pipx install pyinstaller
     - name: Build executable
       run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -33,9 +33,7 @@ jobs:
     #     python -m pip install --upgrade pip
     #     pip install pyinstaller, pyside6
     - name: Build executable
-      run: |
-        source $VENV
-        pyinstaller -y --clean joystick_gremlin.spec
+      run: pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -44,8 +44,8 @@ jobs:
         retention-days: 7
         overwrite: true
     - name: Upload to Nightly release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: Nightly
-          files: dist/joystick_gremlin_nightly.zip
-          token: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: Nightly
+        files: dist/joystick_gremlin_nightly.zip
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -27,11 +27,11 @@ jobs:
     - name: Build executable
       run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     - name: Get current date
-      run: echo "DATE=$(date +'%Y_%m_%d)" >> $GITHUB_STATE
+      run: echo "CURRENT_DATE=$(date +'%Y_%m_%d)" >> $GITHUB_ENV
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_${{ GITHUB_STATE.DATE }}
+        name: joystick_gremlin_nightly_$CURRENT_DATE
         path: dist/
         if-no-files-found: warn
         retention-days: 7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -48,9 +48,13 @@ jobs:
         if-no-files-found: warn
         retention-days: 7
         overwrite: true
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        path: ./
     - name: Upload to Nightly release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: Nightly
-        files: joystick_gremlin_nightly
+        files: ./joystick_gremlin_nightly.zip
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -34,10 +34,18 @@ jobs:
       id: current_date
       run: echo "CURRENT_DATE=$(date +'%Y_%m_%d')" >> "$GITHUB_OUTPUT"
     - name: Upload build
+      env:
+        CURRENT_DATE: ${{ steps.current_date.outputs.CURRENT_DATE }}
       uses: actions/upload-artifact@v4
       with:
-        name: joystick_gremlin_nightly_${{ steps.current_date.outputs.CURRENT_DATE }}
+        name: joystick_gremlin_nightly
         path: dist/
         if-no-files-found: warn
         retention-days: 7
         overwrite: true
+    - name: Upload to Nightly release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: Nightly
+          files: dist/joystick_gremlin_nightly.zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -39,7 +39,7 @@ jobs:
     #     pip install pyinstaller
     #     pip install PySide6
     - name: Build executable
-      run: pyinstaller -y --clean joystick_gremlin.spec
+      run: poetry run pyinstaller -y --clean joystick_gremlin.spec
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/joystick_gremlin.spec
+++ b/joystick_gremlin.spec
@@ -55,7 +55,12 @@ hidden_imports = [
     "gremlin.ui.device",
     "gremlin.ui.profile",
     "gremlin.ui.util",
-    "PySide6",
+    # PySide
+    "PySide6.QtCore",
+    "PySide6.QtGui",
+    "PySide6.QtQml",
+    "PySide6.QtQuick",
+    "PySide6.QtWidgets",
 ]
 
 a = Analysis(

--- a/joystick_gremlin.spec
+++ b/joystick_gremlin.spec
@@ -55,12 +55,6 @@ hidden_imports = [
     "gremlin.ui.device",
     "gremlin.ui.profile",
     "gremlin.ui.util",
-    # PySide
-    "PySide6.QtCore",
-    "PySide6.QtGui",
-    "PySide6.QtQml",
-    "PySide6.QtQuick",
-    "PySide6.QtWidgets",
 ]
 
 a = Analysis(

--- a/joystick_gremlin.spec
+++ b/joystick_gremlin.spec
@@ -55,6 +55,7 @@ hidden_imports = [
     "gremlin.ui.device",
     "gremlin.ui.profile",
     "gremlin.ui.util",
+    "PySide6",
 ]
 
 a = Analysis(


### PR DESCRIPTION
Utilizes GitHub actions to build a Gremlin release from the current development branch.

- Utilizes poetry to install dependencies
- PyInstaller builds the code
- Compress the resulting executable and associated files in a date-versioned zip file
- Upload the archive to the [Nightly release](https://github.com/WhiteMagic/JoystickGremlin/releases/tag/Nightly)
