### PR TITLE
Add ci workflow to run unit tests

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request_target' &&

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,40 @@
+name: CI Tests
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request_target:
+    branches: [ "**" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' &&
+       (github.event.pull_request.user.login == github.repository_owner ||
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR' ||
+        contains(github.event.pull_request.labels.*.name, 'gh-actions-manager')))
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "latest"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests
+        run: poetry run pytest test/unit

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -54,8 +54,13 @@ class Configuration:
         self._last_reload = None
         self.load()
 
-        self.watcher = QtCore.QFileSystemWatcher([_config_file_path])
-        self.watcher.fileChanged.connect(self.load)
+        self.watcher = None  # See ensure_watcher_running()
+        
+    def ensure_watcher_running(self):
+        """Only call this after configuring the rest of the Qt app."""
+        if self.watcher is None:
+            self.watcher = QtCore.QFileSystemWatcher([_config_file_path])
+            self.watcher.fileChanged.connect(self.load)
 
     def count(self) -> int:
         """Returns the number of parameters stored.

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -54,14 +54,6 @@ class Configuration:
         self._last_reload = None
         self.load()
 
-        self.watcher = None  # See ensure_watcher_running()
-        
-    def ensure_watcher_running(self):
-        """Only call this after configuring the rest of the Qt app."""
-        if self.watcher is None:
-            self.watcher = QtCore.QFileSystemWatcher([_config_file_path])
-            self.watcher.fileChanged.connect(self.load)
-
     def count(self) -> int:
         """Returns the number of parameters stored.
 
@@ -138,15 +130,13 @@ class Configuration:
                 "expose": entry["expose"]
             }
 
-        try:
-            # Write data to file
-            with open(_config_file_path, "w") as hdl:
-                encoder = json.JSONEncoder(sort_keys=True, indent=4)
-                hdl.write(encoder.encode(json_data))
-        except FileNotFoundError as e:
-            logging.getLogger("system").exception(
-                f"Failed to save configuration file: {e}"
+        # Write data to file
+        with open(_config_file_path, "w") as hdl:
+            encoder = json.JSONEncoder(
+                sort_keys=True,
+                indent=4
             )
+            hdl.write(encoder.encode(json_data))
 
     def register(
         self,

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -133,13 +133,15 @@ class Configuration:
                 "expose": entry["expose"]
             }
 
-        # Write data to file
-        with open(_config_file_path, "w") as hdl:
-            encoder = json.JSONEncoder(
-                sort_keys=True,
-                indent=4
+        try:
+            # Write data to file
+            with open(_config_file_path, "w") as hdl:
+                encoder = json.JSONEncoder(sort_keys=True, indent=4)
+                hdl.write(encoder.encode(json_data))
+        except FileNotFoundError as e:
+            logging.getLogger("system").exception(
+                f"Failed to save configuration file: {e}"
             )
-            hdl.write(encoder.encode(json_data))
 
     def register(
         self,

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -327,6 +327,7 @@ def make_gremlin_app(argv):
     # Run UI
     syslog.info("Gremlin UI launching")
     app.aboutToQuit.connect(shutdown_cleanup)
+    cfg.ensure_watcher_running()
     return app
 
 

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -327,7 +327,6 @@ def make_gremlin_app(argv):
     # Run UI
     syslog.info("Gremlin UI launching")
     app.aboutToQuit.connect(shutdown_cleanup)
-    cfg.ensure_watcher_running()
     return app
 
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -24,9 +24,11 @@ def _make_fake_device(is_virtual: bool) -> dill.DeviceSummary:
         Data4=(128, 4, 68, 69, 83, 84, 0, 0),
     )
     axis_map_array = (dill._AxisMap * 8)()
-    for i in range(8):
+    for i, (linear_i, axis_i) in enumerate(
+        [(1, 1), (2, 2), (3, 3), (4, 6), (5, 7), (6, 8), (7, 0), (8, 0)]
+    ):
         axis_map_array[i] = axis_map = dill._AxisMap(
-            linear_index=i + 1, axis_index=i + 1
+            linear_index=linear_i, axis_index=axis_i
         )
     return dill.DeviceSummary(
         dill._DeviceSummary(
@@ -35,9 +37,9 @@ def _make_fake_device(is_virtual: bool) -> dill.DeviceSummary:
             product_id=0xBEAD if is_virtual else 0xFACE,
             joystick_id=0 if is_virtual else 1,
             name=b"vJoy Device" if is_virtual else b"pJoy Pro",
-            axis_count=8,
-            button_count=128,
-            hat_count=4,
+            axis_count=6,
+            button_count=64,
+            hat_count=2,
             axis_map=axis_map_array,
         )
     )
@@ -78,19 +80,19 @@ def joystick_init():
             vjoy,
             vjoy.axis_count.__name__,
             autospec=True,
-            return_value=8,
+            return_value=6,
         ),
         mock.patch.object(
             vjoy,
             vjoy.button_count.__name__,
             autospec=True,
-            return_value=128,
+            return_value=64,
         ),
         mock.patch.object(
             vjoy,
             vjoy.hat_count.__name__,
             autospec=True,
-            return_value=4,
+            return_value=2,
         ),
         mock.patch.object(
             vjoy,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,8 +7,15 @@ import pytest
 
 import dill
 
+# Import creates required user profile directory.
+import joystick_gremlin
 import gremlin.device_initialization
 import gremlin.event_handler
+
+
+@pytest.fixture(scope="package", autouse=True)
+def register_config_options():
+    joystick_gremlin.register_config_options()
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -2,15 +2,45 @@ import sys
 sys.path.append(".")
 
 import pathlib
-
-import pytest
+from unittest import mock
 
 import dill
+import pytest
+from vjoy import vjoy
 
 # Import creates required user profile directory.
 import joystick_gremlin
 import gremlin.device_initialization
 import gremlin.event_handler
+
+
+def _make_fake_device(is_virtual: bool) -> dill.DeviceSummary:
+    """Creates a repeatable, faked DeviceSummary."""
+    # Data below was generated from a vJoy device.
+    guid = dill._GUID(
+        Data1=501018480 + int(is_virtual),
+        Data2=264,
+        Data3=4592,
+        Data4=(128, 4, 68, 69, 83, 84, 0, 0),
+    )
+    axis_map_array = (dill._AxisMap * 8)()
+    for i in range(8):
+        axis_map_array[i] = axis_map = dill._AxisMap(
+            linear_index=i + 1, axis_index=i + 1
+        )
+    return dill.DeviceSummary(
+        dill._DeviceSummary(
+            device_guid=guid,
+            vendor_id=0x1234 if is_virtual else 0x5678,
+            product_id=0xBEAD if is_virtual else 0xFACE,
+            joystick_id=0 if is_virtual else 1,
+            name=b"vJoy Device" if is_virtual else b"pJoy Pro",
+            axis_count=8,
+            button_count=128,
+            hat_count=4,
+            axis_map=axis_map_array,
+        )
+    )
 
 
 @pytest.fixture(scope="package", autouse=True)
@@ -21,7 +51,55 @@ def register_config_options():
 @pytest.fixture(scope="package", autouse=True)
 def joystick_init():
     dill.DILL.init()
-    gremlin.device_initialization.joystick_devices_initialization()
+    di_stub_devices = {
+        0: _make_fake_device(is_virtual=False),
+        1: _make_fake_device(is_virtual=True),
+    }
+    with (
+        mock.patch.object(
+            dill.DILL,
+            dill.DILL.get_device_count.__name__,
+            autospec=True,
+            return_value=len(di_stub_devices),
+        ),
+        mock.patch.object(
+            dill.DILL,
+            dill.DILL.get_device_information_by_index.__name__,
+            autospec=True,
+            side_effect=di_stub_devices.get,
+        ),
+        mock.patch.object(
+            vjoy,
+            vjoy.device_exists.__name__,
+            autospec=True,
+            side_effect=lambda vjoy_id: vjoy_id == 1,  # A single vJoy device.
+        ),
+        mock.patch.object(
+            vjoy,
+            vjoy.axis_count.__name__,
+            autospec=True,
+            return_value=8,
+        ),
+        mock.patch.object(
+            vjoy,
+            vjoy.button_count.__name__,
+            autospec=True,
+            return_value=128,
+        ),
+        mock.patch.object(
+            vjoy,
+            vjoy.hat_count.__name__,
+            autospec=True,
+            return_value=4,
+        ),
+        mock.patch.object(
+            vjoy,
+            vjoy.hat_configuration_valid.__name__,
+            autospec=True,
+            return_value=True,
+        ),
+    ):
+        gremlin.device_initialization.joystick_devices_initialization()
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/vjoy/vjoy.py
+++ b/vjoy/vjoy.py
@@ -941,7 +941,7 @@ class VJoyProxy:
                 device = VJoy(index)
                 VJoyProxy.vjoy_devices[index] = device
                 return device
-            except error.VJoyError as e:
+            except VJoyError as e:
                 logging.getLogger("system").error(
                     f"Failed accessing vJoy id={index}, error is: {e}"
                 )


### PR DESCRIPTION
I had to modify a bit of Gremlin internals to make all this work. Specifically:

1302efd03a1a72d76fe1bb061694add8456ba529: changes how the `Configuration` file watcher starts. Need to prevent access violation on exit from unit tests (integration tests don't have this issue because they run/initialize(?) the Qt app - my comment for `ensure_watcher_running` might be inaccurate).

54b66c1fcc18c0be0e1315667422f31c779da053: Does not throw an exception if the configuration file was not found when attempting to save it. The idea is that this shouldn't happen during normal Gremlin execution because the profile directory is created at the module level in `joystick_gremlin.py`. Let me know if you have a better idea.

Fixes #613 