### PR TITLE
Detect and handle concurrent vJoy instantiation attempt

### DIFF
--- a/gremlin/error.py
+++ b/gremlin/error.py
@@ -77,6 +77,14 @@ class VJoyError(GremlinError):
         super().__init__(value)
 
 
+class VJoyConcurrencyError(VJoyError):
+
+    """Exception raised when vJoy is accessed from multiple threads."""
+
+    def __init__(self, value):
+        super().__init__(value)
+
+
 class PluginError(GremlinError):
 
     """Exception raised when an error occurs withing a user plugin."""


### PR DESCRIPTION
Workaround for #635 

I couldn't replicate the bug anymore. The system log shows that the handler did get invoked:

```
2025-09-17 02:10:01      ERROR vJoy device 1 is already acquired by this process
NoneType: None
2025-09-17 02:10:01       INFO Concurrent instantiation attempt=1 for vJoy index=1, retrying...
```

(Re the `NoneType: None` it seems the `exception()` call in `error.GremlinError` is unable to find an exception to log...)