### PR TITLE
Add E2E integration test for macros - vjoy output actions only

### DIFF
--- a/test/integration/test_e2e_macro.py
+++ b/test/integration/test_e2e_macro.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Integration tests with a profile with macros that have vJoy outputs.
+"""
+
+import sys
+
+sys.path.append(".")
+
+import pytest
+
+import dill
+from test.integration import app_tester
+from vjoy import vjoy
+
+
+@pytest.fixture(scope="module")
+def profile_name() -> str:
+    """Returns the name of the profile to be used for the macro test.
+
+    The profile maps button 1 press to vJoy actions of each type: button press,
+    hat direction set, absolute axis set, and relative axis change.
+    """
+    return "e2e_macros.xml"
+
+
+class TestMacro:
+    """Tests the vJoy actions of macro.py."""
+
+    def test_macro_sequence(
+        self,
+        subtests,
+        tester: app_tester.GremlinAppTester,
+        vjoy_control_device: vjoy.VJoy,
+        vjoy_di_device: dill.DeviceSummary,
+    ):
+        """Verifies multiple macro executions triggered by a single button press."""
+        input_button_id = 1
+        vjoy_output = 1
+        cached_value = True
+        vjoy_control_device.button(index=input_button_id).is_pressed = True
+        tester.assert_button_eventually_equals(
+            vjoy_di_device.device_guid, input_button_id, vjoy_output
+        )
+        tester.assert_cached_button_eventually_equals(
+            vjoy_di_device.device_guid.uuid, input_button_id, cached_value
+        )
+
+        def assert_fixed_outputs(step: int):
+            with subtests.test("hat northeast", step=step):
+                tester.assert_hat_eventually_equals(vjoy_di_device.device_guid, 1, 4500)
+            with subtests.test("hat west", step=step):
+                tester.assert_hat_eventually_equals(
+                    vjoy_di_device.device_guid, 2, 27000
+                )
+            with subtests.test("button", step=step):
+                tester.assert_button_eventually_equals(vjoy_di_device.device_guid, 3, 1)
+            with subtests.test("axis absolute positive", step=step):
+                tester.assert_axis_eventually_equals(
+                    vjoy_di_device.device_guid, 2, tester.AXIS_MAX_INT * 0.7
+                )
+            with subtests.test("axis absolute negative", step=step):
+                tester.assert_axis_eventually_equals(
+                    vjoy_di_device.device_guid, 3, tester.AXIS_MAX_INT * -0.5
+                )
+
+        assert_fixed_outputs(step=1)
+        with subtests.test("axis relative positive", step=1):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 5, tester.AXIS_MAX_INT * 0.2
+            )
+        with subtests.test("axis relative negative", step=1):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 6, tester.AXIS_MAX_INT * -0.1
+            )
+
+        vjoy_control_device.button(index=input_button_id).is_pressed = False
+        assert_fixed_outputs(step=2)
+        with subtests.test("axis relative positive", step=2):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 5, tester.AXIS_MAX_INT * 0.2
+            )
+        with subtests.test("axis relative negative", step=2):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 6, tester.AXIS_MAX_INT * -0.1
+            )
+
+        vjoy_control_device.button(index=input_button_id).is_pressed = True
+        assert_fixed_outputs(step=3)
+        with subtests.test("axis relative positive", step=3):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 5, tester.AXIS_MAX_INT * 0.2 * 2
+            )
+        with subtests.test("axis relative negative", step=3):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 6, tester.AXIS_MAX_INT * -0.1 * 2
+            )
+
+        vjoy_control_device.button(index=input_button_id).is_pressed = False
+        assert_fixed_outputs(step=4)
+        vjoy_control_device.button(index=input_button_id).is_pressed = True
+        assert_fixed_outputs(step=5)
+        with subtests.test("axis relative positive", step=5):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 5, tester.AXIS_MAX_INT * 0.2 * 3
+            )
+        with subtests.test("axis relative negative", step=5):
+            tester.assert_axis_eventually_equals(
+                vjoy_di_device.device_guid, 6, tester.AXIS_MAX_INT * -0.1 * 3
+            )

--- a/test/integration/xml/e2e_macros.xml
+++ b/test/integration/xml/e2e_macros.xml
@@ -1,0 +1,203 @@
+﻿<?xml version="1.0" ?>
+<profile version="14">
+    <inputs>
+        <input>
+            <device-id>97b77b40-07d8-11f0-8028-444553540000</device-id>
+            <input-type>button</input-type>
+            <mode>Default</mode>
+            <input-id>1</input-id>
+            <action-configuration>
+                <root-action>7c55893e-ceff-4038-8223-0b8a5294b392</root-action>
+                <behavior>button</behavior>
+            </action-configuration>
+        </input>
+    </inputs>
+    <logical-device/>
+    <library>
+        <action id="5daa1184-c5e9-4316-9a66-c4143c51a6b9" type="macro">
+            <property type="bool">
+                <name>is-exclusive</name>
+                <value>False</value>
+            </property>
+            <property type="string">
+                <name>repeat-mode</name>
+                <value>Single</value>
+            </property>
+            <property type="int">
+                <name>repeat-count</name>
+                <value>3</value>
+            </property>
+            <property type="float">
+                <name>repeat-delay</name>
+                <value>0.8</value>
+            </property>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>hat</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>1</value>
+                </property>
+                <property type="hat_direction">
+                    <name>value</name>
+                    <value>north-east</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>hat</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>2</value>
+                </property>
+                <property type="hat_direction">
+                    <name>value</name>
+                    <value>west</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>button</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>3</value>
+                </property>
+                <property type="bool">
+                    <name>value</name>
+                    <value>True</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>axis</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>2</value>
+                </property>
+                <property type="float">
+                    <name>value</name>
+                    <value>0.7</value>
+                </property>
+                <property type="axis_mode">
+                    <name>axis-mode</name>
+                    <value>absolute</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>axis</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>3</value>
+                </property>
+                <property type="float">
+                    <name>value</name>
+                    <value>-0.5</value>
+                </property>
+                <property type="axis_mode">
+                    <name>axis-mode</name>
+                    <value>absolute</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>axis</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>5</value>
+                </property>
+                <property type="float">
+                    <name>value</name>
+                    <value>0.2</value>
+                </property>
+                <property type="axis_mode">
+                    <name>axis-mode</name>
+                    <value>relative</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>axis</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>6</value>
+                </property>
+                <property type="float">
+                    <name>value</name>
+                    <value>-0.1</value>
+                </property>
+                <property type="axis_mode">
+                    <name>axis-mode</name>
+                    <value>relative</value>
+                </property>
+            </macro-action>
+            <property type="string">
+                <name>action-label</name>
+                <value>Macro</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>press</value>
+            </property>
+        </action>
+        <action id="7c55893e-ceff-4038-8223-0b8a5294b392" type="root">
+            <actions>
+                <action-id>5daa1184-c5e9-4316-9a66-c4143c51a6b9</action-id>
+            </actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Root</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+    </library>
+    <modes>
+        <mode>Default</mode>
+    </modes>
+    <scripts/>
+</profile>


### PR DESCRIPTION
Since `macro.py` has a bit of direct vJoy usage (and it didn't seem to make sense to try share code with `map_to_vjoy` action), I am adding a simple E2E integration test focused on the vJoy outputs part.

Rest of the macro should be tested using logical device I/O