### PR TITLE
Fix bug where periodics were being registered multiple times (or, at …

### DIFF
--- a/gremlin/user_script.py
+++ b/gremlin/user_script.py
@@ -535,6 +535,8 @@ class Script:
     def reload(self):
         Script.variable_registry.register_script(self)
         self.module._script_id = self.id
+        # Clear periodic registry to avoid duplicate entries.
+        periodic_registry.clear()
         self.spec.loader.exec_module(self.module)
 
     def _retrieve_variable_definitions(self):


### PR DESCRIPTION
…least twice)

Otherwise when running the script, this code in `user_script.py`:

```
    def _thread_loop(self) -> None:
        """Main execution loop run in a separate thread."""
        ...
        # Populate the queue
        self._queue = []
        for item in self._registry.values():
            plugin_cb = self._install_plugins(item[1])
            callback_map[plugin_cb] = item[0]
            heapq.heappush(
                self._queue,
                (time.time() + callback_map[plugin_cb], plugin_cb)
            )
```

raises an exception because there are two 2-tuples in `self._queue` with exactly the same timestamp.