### PR TITLE
Fix bug where script manager UI was showing wrong scripts

### DIFF
--- a/gremlin/ui/script.py
+++ b/gremlin/ui/script.py
@@ -380,13 +380,9 @@ class ScriptListModel(QtCore.QAbstractListModel):
 
     @Slot(str)
     def addScript(self, path: str) -> None:
-        self.beginInsertRows(
-            QtCore.QModelIndex(),
-            self.rowCount(),
-            self.rowCount()
-        )
+        self.layoutAboutToBeChanged.emit()
         self._script_manager.add_script(Path(path))
-        self.endInsertRows()
+        self.layoutChanged.emit()
 
     @Slot(str, str)
     def removeScript(self, path: str, name: str) -> None:


### PR DESCRIPTION
The script manager sorts the scripts, but the model doesn't know that this happened.

AI suggested that the layout change signals are more efficient then doing a `modelReset` emit.