### PR TITLE
Don't try loading user plugins if the directory is not set in configuration

### DIFF
--- a/gremlin/plugin_manager.py
+++ b/gremlin/plugin_manager.py
@@ -49,11 +49,13 @@ class PluginManager:
         self._parameter_requirements = {}
 
         self._discover_plugins(Path(util.resource_path("action_plugins")), True)
-        path = Path(config.Configuration().value(
+        user_plugin_dir = config.Configuration().value(
             "global", "general", "plugin_directory"
-        ))
-        if path.is_dir():
-            self._discover_plugins(path, False)
+        )
+        if user_plugin_dir:
+            path = Path(user_plugin_dir)
+            if path.is_dir():
+                self._discover_plugins(path, False)
 
         self._create_type_action_map()
         self._create_action_name_map()


### PR DESCRIPTION
Otherwise, it defaults to the current working directory, which leads to:

1. Normal (not packaged) Gremlin runs traversing through the whole Gremlin tree
2. Runs via IDE plugins (pytest, debugpy) failing to run tests with the following exception:

```
    def test_hierarchy(xml_dir: pathlib.Path):
>       gremlin.plugin_manager.PluginManager()

c:\Users\Code Monet\Documents\GitHub\JoystickGremlin\test\unit\test_profile.py:74: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
c:\Users\Code Monet\Documents\GitHub\JoystickGremlin\gremlin\common.py:34: in __call__
    self.instance = self.klass(*args, **kwargs)
c:\Users\Code Monet\Documents\GitHub\JoystickGremlin\gremlin\plugin_manager.py:56: in __init__
    self._discover_plugins(path, False)
c:\Users\Code Monet\Documents\GitHub\JoystickGremlin\gremlin\plugin_manager.py:198: in _discover_plugins
    raise(e)
c:\Users\Code Monet\Documents\GitHub\JoystickGremlin\gremlin\plugin_manager.py:162: in _discover_plugins
    plugin = importlib.import_module(plugin_module_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = '.', package = None

    def import_module(name, package=None):
        """Import a module.
    
        The 'package' argument is required when performing a relative import. It
        specifies the package to use as the anchor point from which to resolve the
        relative import to an absolute import.
    
        """
        level = 0
        if name.startswith('.'):
            if not package:
>               raise TypeError("the 'package' argument is required to perform a "
                                f"relative import for {name!r}")
E               TypeError: the 'package' argument is required to perform a relative import for '.'
```

In this case of IDE plugins, what's happening is that the current working directory is the path of the plugin, which happens to have an `__init__.py`, which leads to the plugin manager attempt to load the module `.`