### PR TITLE
Feature: Add support for emta option dialogs and action ordering

### DIFF
--- a/gremlin/base_classes.py
+++ b/gremlin/base_classes.py
@@ -80,6 +80,15 @@ class AbstractActionData(ABC):
 
     """Base class holding the data of all action related data classes."""
 
+    version = None
+    name = None
+    tag = None
+    icon = None
+    functor = None
+    model = None
+    properties = []
+    input_types: List[InputType] = []
+
     def __init__(self, behavior_type: InputType=InputType.JoystickButton) -> None:
         """Creates a new action data instance.
 

--- a/gremlin/base_classes.py
+++ b/gremlin/base_classes.py
@@ -80,6 +80,9 @@ class AbstractActionData(ABC):
 
     """Base class holding the data of all action related data classes."""
 
+    # Fields expected to be present in every action plugin. These define
+    # information required by the plugin manager as well as UI and behavior
+    # logic.
     version = None
     name = None
     tag = None

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -40,8 +40,7 @@ _required_properties = {
 }
 
 
-@common.SingletonDecorator
-class Configuration:
+class Configuration(metaclass=common.SingletonMetaclass):
 
     """Responsible for loading and saving configuration data."""
 
@@ -58,10 +57,6 @@ class Configuration:
             Number of parameters stored by the configuration.
         """
         return len(self._data)
-
-    def _should_skip_reload(self) -> bool:
-        """Returns True if the last load() was less than 1 second ago."""
-        return self._last_reload is not None and time.time() - self._last_reload < 1
 
     def load(self) -> None:
         """Loads the configuration file's content."""
@@ -489,6 +484,17 @@ class Configuration:
             raise error.GremlinError(f"No parameter with key {key} exists")
 
         return self._data[key][entry]
+
+    def _should_skip_reload(self) -> bool:
+        """Returns True if the last load() was less than 1 second ago.
+
+        Prevents reloading the configuration file too often.
+
+        Returns:
+            True if reloading of the configuration should be skipped.
+        """
+        return self._last_reload is not None and \
+            time.time() - self._last_reload < 1.0
 
     # def get_executable_list(self):
     #     """Returns a list of all executables with associated profiles.

--- a/gremlin/plugin_manager.py
+++ b/gremlin/plugin_manager.py
@@ -23,11 +23,12 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from PySide6 import QtQml
 
-from gremlin import common, config, error, shared_state, util
+from gremlin import config, error, shared_state, util
+from gremlin.common import SingletonMetaclass
 from gremlin.types import ActionProperty, InputType, DataCreationMode
 
 if TYPE_CHECKING:
@@ -38,8 +39,7 @@ if TYPE_CHECKING:
     PluginDict = dict[str, Plugin]
 
 
-@common.SingletonDecorator
-class PluginManager:
+class PluginManager(metaclass=SingletonMetaclass):
 
     """Handles discovery and management of action plugins."""
 
@@ -75,7 +75,7 @@ class PluginManager:
         """Returns a mapping from input types to valid action plugins.
 
         Returns:
-            Mmapping from input types to associated actions.
+            Mapping from input types to associated actions.
         """
         return self._type_to_action_map
 
@@ -110,7 +110,8 @@ class PluginManager:
         """Returns the list of plugins requiring a certain parameter.
 
         Args:
-            param_name: The parameter name required by the returned actions.
+            param_name: Name of the parameter required by all action classes
+                returned.
 
         Returns:
             List of actions requiring a certain parameter in the callback.
@@ -126,10 +127,10 @@ class PluginManager:
 
         Args:
             name: Name of the action to create an instance of.
-            input_type: The input type associated with the new instance.
+            input_type: Input type associated with the new instance.
 
         Returns:
-            The newly created action instance.
+            Newly created action instance.
         """
         cls = self.get_class(name)
         creation_mode = DataCreationMode.Create
@@ -141,7 +142,7 @@ class PluginManager:
 
     def _create_type_action_map(self) -> None:
         """Creates a lookup table from input types to available actions."""
-        self._type_to_action_map : dict[InputType, PluginList]= {
+        self._type_to_action_map : dict[InputType, PluginList] = {
             InputType.JoystickAxis: [],
             InputType.JoystickButton: [],
             InputType.JoystickHat: [],

--- a/gremlin/plugin_manager.py
+++ b/gremlin/plugin_manager.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 @common.SingletonDecorator
 class PluginManager:
 
-    """Handles discovery and handling of action plugins."""
+    """Handles discovery and management of action plugins."""
 
     def __init__(self) -> None:
         """Initializes the action plugin manager."""
@@ -65,7 +65,8 @@ class PluginManager:
     def repository(self) -> PluginDict:
         """Returns the dictionary of all found plugins.
 
-        :return dictionary containing all plugins found
+        Returns:
+            Dictionary containing all plugins found.
         """
         return self._plugins
 
@@ -73,7 +74,8 @@ class PluginManager:
     def type_action_map(self) -> dict[InputType, PluginList]:
         """Returns a mapping from input types to valid action plugins.
 
-        :return mapping from input types to associated actions
+        Returns:
+            Mmapping from input types to associated actions.
         """
         return self._type_to_action_map
 
@@ -81,15 +83,19 @@ class PluginManager:
     def tag_map(self) -> PluginDict:
         """Returns the mapping from an action tag to the action plugin.
 
-        :return mapping from action name to action plugin
+        Returns:
+            Mapping from action name to action plugin.
         """
         return self._tag_to_type_map
 
     def get_class(self, name: str) -> Plugin:
         """Returns the class object corresponding to the given name.
 
-        :param name of the action class to return
-        :return class object corresponding to the provided name
+        Args:
+            name: Name of the action class to return.
+
+        Returns:
+            Action class object corresponding to the provided name.
         """
         if name not in self._name_to_type_map:
             raise error.GremlinError(
@@ -103,8 +109,11 @@ class PluginManager:
     ) -> PluginList:
         """Returns the list of plugins requiring a certain parameter.
 
-        :param param_name the parameter name required by the returned actions
-        :return list of actions requiring a certain parameter in the callback
+        Args:
+            param_name: The parameter name required by the returned actions.
+
+        Returns:
+            List of actions requiring a certain parameter in the callback.
         """
         return self._parameter_requirements.get(param_name, [])
 
@@ -116,11 +125,11 @@ class PluginManager:
         """Creates an action instance which is stored in the library.
 
         Args:
-            name: name of the action to create an instance of
-            input_type: the input type associated with the new instance
+            name: Name of the action to create an instance of.
+            input_type: The input type associated with the new instance.
 
         Returns:
-            The newly created action instance
+            The newly created action instance.
         """
         cls = self.get_class(name)
         creation_mode = DataCreationMode.Create
@@ -144,7 +153,7 @@ class PluginManager:
                 self._type_to_action_map[input_type].append(entry)
 
     def _create_action_name_map(self) -> None:
-        """Creates a lookup table from action names to actions."""
+        """Creates lookup tables from action name and tag to actions."""
         for entry in self._plugins.values():
             self._name_to_type_map[entry.name] = entry
             self._tag_to_type_map[entry.tag] = entry
@@ -153,9 +162,9 @@ class PluginManager:
         """Processes known plugin folders for action plugins.
 
         Args:
-            path: path to the folder to scan for action plugins
-            is_core: whether the folder is part of the core Gremlin or user
-                specified
+            path: Path to the folder to scan for action plugins.
+            is_core: Whether the folder is part of the core Gremlin or user
+                specified.
         """
         if not is_core:
             sys.path.insert(0, str(path))

--- a/gremlin/ui/action_model.py
+++ b/gremlin/ui/action_model.py
@@ -318,6 +318,15 @@ class ActionModel(QtCore.QObject):
             signal.reloadUi.emit()
 
     def _compatible_actions(self) -> List[str]:
+        """Returns the names of actions that are compatible within the current
+        context.
+
+        The list of action names are filtered and sorted based on user
+        preferences.
+
+        Returns:
+            List of currently valid actions.
+        """
         key = ["global", "general", "action_priorities"]
         priority_list = Configuration().value(*key)
 

--- a/gremlin/ui/option.py
+++ b/gremlin/ui/option.py
@@ -200,3 +200,31 @@ class ConfigEntryModel(QtCore.QAbstractListModel):
 
     def roleNames(self) -> Dict[int, QtCore.QByteArray]:
         return self.roles
+
+
+class MetaConfigOption:
+
+    def register_meta_option(
+        self,
+        section: str,
+        group: str,
+        name: str,
+        description: str,
+        qml_element: str
+    ) -> None:
+        """Registers an option that does not directly contain a value.
+
+        This allows register option items of a more complex nature that have a
+        dedicate QML UI element to them which handles the UI configuring the
+        content and also the logic to persist the data to the Configuration
+        class.
+
+        Args:
+            section: overall section this option is associated with
+            group: grouping into which the option belongs
+            name: name by which the new option is shown
+            description: description of the parameter's purpose
+            qml_element: path to the QML to load for this option
+        """
+        pass
+

--- a/gremlin/ui/option.py
+++ b/gremlin/ui/option.py
@@ -309,6 +309,21 @@ class ActionSequenceOrdering(QtCore.QAbstractListModel, BaseMetaConfigOptionWidg
         else:
             raise GremlinError("Invalid role encountered")
 
+    def setData(
+            self,
+            index: ta.ModelIndex,
+            value: Any,
+            role: int=QtCore.Qt.ItemDataRole.EditRole
+    ) -> bool:
+        data = self._config.value(*self._cfg_key)
+        match self.roles[role]:
+            case "visible":
+                data[index.row()][1] = value
+                self._config.set(*self._cfg_key, data)
+                return True
+            case _:
+                return False
+
     def roleNames(self) -> Dict[int, QtCore.QByteArray]:
         return self.roles
 

--- a/gremlin/ui/option.py
+++ b/gremlin/ui/option.py
@@ -183,10 +183,8 @@ class ConfigEntryModel(QtCore.QAbstractListModel):
         if role in self.roles:
             role_name = bytes(self.roles[role].data()).decode()
 
-            # TODO: Figure out if we need to retrieve an option or a config
-            #       entry and handle it accordingly.
-            # Special handling
             name = entries[index.row()]
+            # Separate handling of config and meta option entries.
             if self._config.exists(self._section_name, self._group_name, name):
                 value = self._config.get(
                     self._section_name,
@@ -206,7 +204,6 @@ class ConfigEntryModel(QtCore.QAbstractListModel):
                         value = self._option.qml_widget(
                             self._section_name, self._group_name, name
                         )().qml_path
-                        print(value)
                     case "data_type":
                         value = "meta_option"
         return value
@@ -257,20 +254,6 @@ class BaseMetaConfigOptionWidget:
             "BaseMetaConfigOptionWidget: Subclasses must implement the " +
             "qml_path method."
         )
-
-
-# @QtQml.QmlElement
-# class OptionTestWidget(BaseMetaConfigOptionWidget):
-
-    timeChanged = Signal()
-
-    def _qml_path(self) -> str:
-        return "file:///" + QtCore.QFile("qml:OptionTest.qml").fileName()
-
-    @Property(float, notify=timeChanged)
-    def timeNow(self) -> float:
-        import time
-        return time.time()
 
 
 @QtQml.QmlElement
@@ -333,7 +316,6 @@ class ActionSequenceOrdering(QtCore.QAbstractListModel, BaseMetaConfigOptionWidg
 
     @Slot(int, int)
     def move(self, source_index: int, target_index: int) -> None:
-        print(f"Moving from {source_index} to {target_index}")
         self.layoutAboutToBeChanged.emit()
         data = self._config.value(*self._cfg_key)
         item = data.pop(source_index)

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -68,7 +68,7 @@ import gremlin.types
 import gremlin.signal
 
 import gremlin.ui.backend
-import gremlin.ui.config
+import gremlin.ui.option
 
 
 def configure_logger(config: Dict[str, Any]) -> None:

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -157,15 +157,18 @@ def update_action_priorities() -> None:
     priorities = []
     if cfg.exists(*key):
         priorities = cfg.value(*key)
-    priorities_tags = [v[0] for v in priorities]
-    plugin_tags = gremlin.plugin_manager.PluginManager().repository.keys()
+    priority_names = [v[0] for v in priorities]
+    plugin_names = [
+        p.name for p in
+        gremlin.plugin_manager.PluginManager().repository.values()
+    ]
 
-    for tag in plugin_tags:
-        if tag not in priorities_tags:
+    for tag in plugin_names:
+        if tag not in priority_names:
             priorities.append((tag, True))
     to_delete = []
-    for i, tag in enumerate(priorities_tags):
-        if tag not in plugin_tags:
+    for i, tag in enumerate(priority_names):
+        if tag not in plugin_names:
             to_delete.append(i)
     for idx in reversed(to_delete):
         del priorities[idx]

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -262,6 +262,7 @@ def make_gremlin_app(argv: List[str]) -> QtWidgets.QApplication:
         "core_plugins",
         gremlin.util.resource_path("action_plugins/")
     )
+    QtCore.QDir.addSearchPath("qml", gremlin.util.resource_path("qml/"))
     cfg = Configuration()
     user_plugins_path = Path(cfg.value("global", "general", "plugin_directory"))
     if user_plugins_path.is_dir():

--- a/qml/ConfigGroup.qml
+++ b/qml/ConfigGroup.qml
@@ -173,6 +173,51 @@ ColumnLayout {
                 }
             }
         }
+        // Meta Option dynamic loading
+        DelegateChoice {
+            roleValue: "meta_option"
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 200
+
+                UIText {
+                    text: description
+                }
+
+                Item {
+                    Layout.fillWidth: true
+
+                    height: _dynamicLoad.item ? _dynamicLoad.item.height : 0
+                    // implicitHeight: _dynamicLoad.item
+                    //     ? (_dynamicLoad.item.implicitHeight > 0
+                    //         ? _dynamicLoad.item.implicitHeight
+                    //             : _dynamicLoad.item.height)
+                    //         : 0
+
+                    Loader {
+                        id: _dynamicLoad
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+
+                        source: Qt.resolvedUrl(value)
+
+                        onStatusChanged: () => {
+                            if (status === Loader.Error) {
+                                console.log(
+                                    "Error loading meta option component from " +
+                                    value + ": " + item);
+                            } else if (status === Loader.Ready) {
+                                // item.Layout.fillHeight = true
+                                // item.height = 300
+                                console.log(item.height);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
     }
 }

--- a/qml/ConfigGroup.qml
+++ b/qml/ConfigGroup.qml
@@ -179,43 +179,73 @@ ColumnLayout {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 200
 
                 UIText {
                     text: description
                 }
 
-                Item {
+                // Dynamic item container
+                DynamicItemLoader {
+                    id: metaLoader
                     Layout.fillWidth: true
 
-                    height: _dynamicLoad.item ? _dynamicLoad.item.height : 0
-                    // implicitHeight: _dynamicLoad.item
-                    //     ? (_dynamicLoad.item.implicitHeight > 0
-                    //         ? _dynamicLoad.item.implicitHeight
-                    //             : _dynamicLoad.item.height)
-                    //         : 0
+                    // 'value' is assumed to be the qrc:/... URL for the meta option QML
+                    qmlPath: value
 
-                    Loader {
-                        id: _dynamicLoad
-
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-
-                        source: Qt.resolvedUrl(value)
-
-                        onStatusChanged: () => {
-                            if (status === Loader.Error) {
-                                console.log(
-                                    "Error loading meta option component from " +
-                                    value + ": " + item);
-                            } else if (status === Loader.Ready) {
-                                // item.Layout.fillHeight = true
-                                // item.height = 300
-                                console.log(item.height);
-                            }
-                        }
+                    // Provide additional properties to the loaded component if needed
+                    // (delete if not required)
+                    injectedProperties: {
+                        // Example placeholders:
+                        // initialValue: model.value,
+                        // description: description
                     }
+
+                    // Optional: force a reload even when file path string stays the same
+                    // forceReloadOnIdenticalPath: true
+
+                    // Optional: react to successful load
+                    onLoaded: (item) => {
+                        // If the loaded item exposes a property you want to initialize,
+                        // you can set it here. Keep empty if not needed.
+                        // console.log("Meta option loaded", item);
+                        console.log("Meta option loaded", item);
+                    }
+
+                    // Optional: log errors
+                    onLoadError: (src, err) => console.warn("Meta option load error:", src, err)
                 }
+
+                // Item {
+                //     Layout.fillWidth: true
+
+                //     height: _dynamicLoad.item ? _dynamicLoad.item.height : 0
+                //     // implicitHeight: _dynamicLoad.item
+                //     //     ? (_dynamicLoad.item.implicitHeight > 0
+                //     //         ? _dynamicLoad.item.implicitHeight
+                //     //             : _dynamicLoad.item.height)
+                //     //         : 0
+
+                //     // Loader {
+                //     //     id: _dynamicLoad
+
+                //     //     anchors.left: parent.left
+                //     //     anchors.right: parent.right
+
+                //     //     source: Qt.resolvedUrl(value)
+
+                //     //     onStatusChanged: () => {
+                //     //         if (status === Loader.Error) {
+                //     //             console.log(
+                //     //                 "Error loading meta option component from " +
+                //     //                 value + ": " + item);
+                //     //         } else if (status === Loader.Ready) {
+                //     //             // item.Layout.fillHeight = true
+                //     //             // item.height = 300
+                //     //             console.log(item.height);
+                //     //         }
+                //     //     }
+                //     // }
+                // }
             }
         }
 

--- a/qml/ConfigGroup.qml
+++ b/qml/ConfigGroup.qml
@@ -184,33 +184,14 @@ ColumnLayout {
                     text: description
                 }
 
-                // Dynamic item container
                 DynamicItemLoader {
-                    id: metaLoader
-                    // Layout.fillWidth: true
-
-                    // 'value' is assumed to be the qrc:/... URL for the meta option QML
                     qmlPath: value
 
-                    // Provide additional properties to the loaded component if needed
-                    // (delete if not required)
-                    injectedProperties: {
-                        // Example placeholders:
-                        // initialValue: model.value,
-                        // description: description
+                    Layout.fillWidth: true
+
+                    onLoadError: (src, err) => {
+                        console.warn("Meta option load error:", src, err)
                     }
-
-                    // Optional: force a reload even when file path string stays the same
-                    // forceReloadOnIdenticalPath: true
-
-                    // Optional: react to successful load
-                    onLoaded: (item) => {
-                        // If the loaded item exposes a property you want to initialize,
-                        // you can set it here. Keep empty if not needed.
-                    }
-
-                    // Optional: log errors
-                    onLoadError: (src, err) => console.warn("Meta option load error:", src, err)
                 }
 
             }

--- a/qml/ConfigGroup.qml
+++ b/qml/ConfigGroup.qml
@@ -187,7 +187,7 @@ ColumnLayout {
                 // Dynamic item container
                 DynamicItemLoader {
                     id: metaLoader
-                    Layout.fillWidth: true
+                    // Layout.fillWidth: true
 
                     // 'value' is assumed to be the qrc:/... URL for the meta option QML
                     qmlPath: value
@@ -207,45 +207,12 @@ ColumnLayout {
                     onLoaded: (item) => {
                         // If the loaded item exposes a property you want to initialize,
                         // you can set it here. Keep empty if not needed.
-                        // console.log("Meta option loaded", item);
-                        console.log("Meta option loaded", item);
                     }
 
                     // Optional: log errors
                     onLoadError: (src, err) => console.warn("Meta option load error:", src, err)
                 }
 
-                // Item {
-                //     Layout.fillWidth: true
-
-                //     height: _dynamicLoad.item ? _dynamicLoad.item.height : 0
-                //     // implicitHeight: _dynamicLoad.item
-                //     //     ? (_dynamicLoad.item.implicitHeight > 0
-                //     //         ? _dynamicLoad.item.implicitHeight
-                //     //             : _dynamicLoad.item.height)
-                //     //         : 0
-
-                //     // Loader {
-                //     //     id: _dynamicLoad
-
-                //     //     anchors.left: parent.left
-                //     //     anchors.right: parent.right
-
-                //     //     source: Qt.resolvedUrl(value)
-
-                //     //     onStatusChanged: () => {
-                //     //         if (status === Loader.Error) {
-                //     //             console.log(
-                //     //                 "Error loading meta option component from " +
-                //     //                 value + ": " + item);
-                //     //         } else if (status === Loader.Ready) {
-                //     //             // item.Layout.fillHeight = true
-                //     //             // item.height = 300
-                //     //             console.log(item.height);
-                //     //         }
-                //     //     }
-                //     // }
-                // }
             }
         }
 

--- a/qml/DynamicItemLoader.qml
+++ b/qml/DynamicItemLoader.qml
@@ -1,0 +1,136 @@
+// -*- coding: utf-8; -*-
+//
+// Copyright (C) 2025
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// ---------------------------------------------------------------------------
+// DynamicItemLoader
+// ---------------------------------------------------------------------------
+// Reusable helper component to load another QML file at runtime (expects a
+// fully-formed qrc:/ or other valid QML source URL already normalized by the
+// caller), integrate it into layouts, and keep sizing (implicitHeight) in
+// sync. Designed to replace ad‑hoc Qt.createComponent usage with a concise
+// declarative Loader wrapper.
+//
+// Features:
+//  * Accepts absolute (Windows/Unix) or relative paths, qrc:, file:/// URLs.
+//  * Optional automatic reload when the path changes.
+//  * Exposes the loaded item via the 'dynamicItem' alias.
+//  * Injects an 'action' object (common pattern in this project) and any
+//    additional key/value pairs via 'injectedProperties'.
+//  * Provides a reload() method to force reloading (e.g. after file overwrite).
+//  * Robust implicitHeight propagation with fallback to height.
+//  * Emits signals on successful load or error.
+// ---------------------------------------------------------------------------
+
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    // Fully-formed QML source URL (e.g. qrc:/... ). Caller guarantees validity.
+    property string qmlPath: ""
+
+    // Optional object passed to a loaded component with an 'action' property.
+    property var action: null
+
+    // Arbitrary properties to set on the created item (after onLoaded).
+    // Example: { someProp: 42, model: myModel }
+    property var injectedProperties: ({})
+
+    // Legacy 'expanded' / 'active' flags removed; component always attempts
+    // to load when qmlPath is set.
+
+    // Automatically reload when qmlPath changes.
+    property bool autoReloadOnPathChange: true
+
+    // Expose the created object for external bindings.
+    property alias dynamicItem: _loader.item
+
+
+    // If true, the loader will be forced to recreate the item when qmlPath
+    // changes even if the new path string is identical (useful after file
+    // overwrites); implemented by briefly toggling active off and on.
+    property bool forceReloadOnIdenticalPath: false
+
+    // Height follows loaded content; fallback to height if implicitHeight unset.
+    implicitHeight: dynamicItem ? (dynamicItem.implicitHeight > 0
+                                   ? dynamicItem.implicitHeight
+                                   : dynamicItem.height) : 0
+
+    // Let layouts stretch us horizontally by default.
+    Layout.fillWidth: true
+    // Always visible; caller can hide externally if needed.
+    visible: true
+
+    signal loaded(Item item)
+    signal loadError(string source, string errorString)
+
+    function reload() {
+        // Force refresh by toggling active when a path exists
+        if (_loader.active) {
+            _loader.active = false;
+            _loader.active = !!root.qmlPath;
+        } else {
+            _loader.active = !!root.qmlPath;
+        }
+    }
+
+    onQmlPathChanged: if (autoReloadOnPathChange) {
+        if (forceReloadOnIdenticalPath)
+            reload();
+        else
+            _loader.active = !!root.qmlPath;
+    }
+
+    // Core Loader doing the work.
+    Loader {
+        id: _loader
+        // Note: 'active' is controlled externally when properties change.
+    active: !!root.qmlPath
+        asynchronous: true
+    source: root.qmlPath
+        anchors.left: parent.left
+        anchors.right: parent.right
+
+        onStatusChanged: {
+            if (status === Loader.Error) {
+                console.log("DynamicItemLoader: error loading", source, errorString());
+                root.loadError(source, errorString());
+            }
+        }
+        onLoaded: {
+            if (item) {
+                // Inject standard action property if present.
+                if (root.action && item.hasOwnProperty("action")) {
+                    item.action = root.action;
+                }
+                // Apply any additional injected properties.
+                if (root.injectedProperties && typeof root.injectedProperties === 'object') {
+                    for (let k in root.injectedProperties) {
+                        try { item[k] = root.injectedProperties[k]; } catch(e) { /* ignore assignment errors */ }
+                    }
+                }
+                // If inside a Layout, ensure it expands horizontally when possible.
+                if (item.Layout) {
+                    item.Layout.fillWidth = true;
+                }
+                root.loaded(item);
+            }
+        }
+    }
+
+}

--- a/qml/DynamicItemLoader.qml
+++ b/qml/DynamicItemLoader.qml
@@ -1,6 +1,6 @@
 // -*- coding: utf-8; -*-
 //
-// Copyright (C) 2025
+// Copyright (C) 2025 Lionel Ott
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,26 +14,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
-// ---------------------------------------------------------------------------
-// DynamicItemLoader
-// ---------------------------------------------------------------------------
-// Reusable helper component to load another QML file at runtime (expects a
-// fully-formed qrc:/ or other valid QML source URL already normalized by the
-// caller), integrate it into layouts, and keep sizing (implicitHeight) in
-// sync. Designed to replace ad‑hoc Qt.createComponent usage with a concise
-// declarative Loader wrapper.
-//
-// Features:
-//  * Accepts absolute (Windows/Unix) or relative paths, qrc:, file:/// URLs.
-//  * Optional automatic reload when the path changes.
-//  * Exposes the loaded item via the 'dynamicItem' alias.
-//  * Injects an 'action' object (common pattern in this project) and any
-//    additional key/value pairs via 'injectedProperties'.
-//  * Provides a reload() method to force reloading (e.g. after file overwrite).
-//  * Robust implicitHeight propagation with fallback to height.
-//  * Emits signals on successful load or error.
-// ---------------------------------------------------------------------------
 
 import QtQuick
 import QtQuick.Layouts
@@ -60,11 +40,15 @@ Item {
     // Expose the created object for external bindings.
     property alias dynamicItem: _loader.item
 
-
     // If true, the loader will be forced to recreate the item when qmlPath
     // changes even if the new path string is identical (useful after file
     // overwrites); implemented by briefly toggling active off and on.
     property bool forceReloadOnIdenticalPath: false
+
+    // Internal flag driving Loader.active to avoid rebinding warnings. We
+    // mutate this property instead of imperatively assigning Loader.active,
+    // keeping the Loader's 'active' binding stable.
+    property bool _activeFlag: false
 
     // Height follows loaded content; fallback to height if implicitHeight unset.
     implicitHeight: dynamicItem ? (dynamicItem.implicitHeight > 0
@@ -80,29 +64,34 @@ Item {
     signal loadError(string source, string errorString)
 
     function reload() {
-        // Force refresh by toggling active when a path exists
-        if (_loader.active) {
-            _loader.active = false;
-            _loader.active = !!root.qmlPath;
-        } else {
-            _loader.active = !!root.qmlPath;
+        // Toggle the flag to force re-instantiation. Use callLater so the
+        // event loop processes deactivation before reactivation.
+        if (!_activeFlag) {
+            _activeFlag = !!root.qmlPath;
+            return;
         }
+        _activeFlag = false;
+        Qt.callLater(function(){
+            _activeFlag = !!root.qmlPath;
+        });
     }
 
     onQmlPathChanged: if (autoReloadOnPathChange) {
         if (forceReloadOnIdenticalPath)
             reload();
         else
-            _loader.active = !!root.qmlPath;
+            _activeFlag = !!root.qmlPath;
     }
+
+    Component.onCompleted: _activeFlag = !!root.qmlPath;
 
     // Core Loader doing the work.
     Loader {
         id: _loader
         // Note: 'active' is controlled externally when properties change.
-    active: !!root.qmlPath
+        active: root._activeFlag
         asynchronous: true
-    source: root.qmlPath
+        source: root.qmlPath
         anchors.left: parent.left
         anchors.right: parent.right
 

--- a/qml/OptionActionSequenceOrdering.qml
+++ b/qml/OptionActionSequenceOrdering.qml
@@ -17,6 +17,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import Gremlin.Config
@@ -65,7 +66,7 @@ Item {
                 y: 0
                 height: 1
 
-                color: "steelblue"
+                color: Universal.accent
                 opacity: parent.containsDrag ? 1.0 : 0.0
             }
         }
@@ -147,7 +148,7 @@ Item {
                 height: 1
                 y: parent.height / 2
 
-                color: "steelblue"
+                color: Universal.accent
                 opacity: parent.containsDrag ? 1.0 : 0.0
             }
         }

--- a/qml/OptionActionSequenceOrdering.qml
+++ b/qml/OptionActionSequenceOrdering.qml
@@ -1,3 +1,20 @@
+// -*- coding: utf-8; -*-
+//
+// Copyright (C) 2025 Lionel Ott
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -6,26 +23,42 @@ import Gremlin.Config
 
 
 Item {
-
     ActionSequenceOrdering {
         id: _data
     }
 
-    implicitHeight: _content.height
+    implicitHeight: _content.implicitHeight
 
-    ColumnLayout {
+    ListView {
         id: _content
 
-        anchors.left: parent.left
-        anchors.right: parent.right
+        implicitHeight: contentHeight
 
-        ListView {
-            model: _data
+        model: _data
 
-            delegate: Text {
-                text: model.name
-            }
+        delegate: Thing {
+            name: model.name
+            active: model.visible
         }
     }
 
+    component Thing : RowLayout {
+        property alias name: _switch.text
+        property alias active: _switch.checked
+
+
+        IconButton {
+            text: bsi.icons.drag_handle
+        }
+        CompactSwitch {
+            id: _switch
+
+            onToggled: () => {
+                // if (model.visible !== checked) {
+                    model.visible = checked
+                // }
+                console.log("Toggled", name, " to ", checked)
+            }
+        }
+    }
 }

--- a/qml/OptionActionSequenceOrdering.qml
+++ b/qml/OptionActionSequenceOrdering.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Gremlin.Config
+
+
+Item {
+
+    ActionSequenceOrdering {
+        id: _data
+    }
+
+    implicitHeight: _content.height
+
+    ColumnLayout {
+        id: _content
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+
+        ListView {
+            model: _data
+
+            delegate: Text {
+                text: model.name
+            }
+        }
+    }
+
+}

--- a/qml/ScriptManager.qml
+++ b/qml/ScriptManager.qml
@@ -165,7 +165,6 @@ Item {
             text: bsi.icons.configure
 
             onClicked: {
-                console.log("Configuring script: " + variables)
                 _config.model = variables
             }
         }

--- a/test/unit/test_meta_config_option.py
+++ b/test/unit/test_meta_config_option.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
+import logging
 import sys
 sys.path.append(".")
 
@@ -45,3 +46,23 @@ def test_basic():
     assert option.description("some", "test", "option 2") == "description 2"
     assert option.qml_element("some", "test", "option 1") == "ui/test1.qml"
     assert option.qml_element("some", "test", "option 2") == "ui/test2.qml"
+
+
+def test_register_duplicate_logs_warning(caplog):
+    option = MetaConfigOption()
+    option.register("dup", "grp", "name", "desc", "ui/elem.qml")
+    option.register("dup", "grp", "name", "desc", "ui/elem.qml")
+
+    assert caplog.record_tuples == [
+        ("system", logging.WARNING, "Option dup.grp.name already registered.")
+    ]
+
+
+def test_retrieve_nonexistent_raises():
+    option = MetaConfigOption()
+    with pytest.raises(gremlin.error.GremlinError):
+        option.qml_element("no", "such", "option")
+
+    option.register("sec", "grp", "name", "desc", "ui/elem.qml")
+    with pytest.raises(gremlin.error.GremlinError):
+        option.description("sec", "grp", "other")

--- a/test/unit/test_meta_config_option.py
+++ b/test/unit/test_meta_config_option.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import sys
+sys.path.append(".")
+
+import pytest
+
+import gremlin.error
+import gremlin.types
+
+from gremlin.ui.option import MetaConfigOption
+
+from gremlin.types import PropertyType
+
+
+def test_basic():
+    option = MetaConfigOption()
+
+    assert option.count() == 0
+
+    option.register("some", "test", "option 1", "description 1", "ui/test1.qml")
+    option.register("some", "test", "option 2", "description 2", "ui/test2.qml")
+
+    assert option.count() == 2
+
+    assert len(option.sections()) == 1
+    assert len(option.groups("some")) == 1
+    assert len(option.entries("some", "test")) == 2
+    assert option.description("some", "test", "option 1") == "description 1"
+    assert option.description("some", "test", "option 2") == "description 2"
+    assert option.qml_element("some", "test", "option 1") == "ui/test1.qml"
+    assert option.qml_element("some", "test", "option 2") == "ui/test2.qml"

--- a/test/unit/test_meta_config_option.py
+++ b/test/unit/test_meta_config_option.py
@@ -24,9 +24,15 @@ import pytest
 import gremlin.error
 import gremlin.types
 
-from gremlin.ui.option import MetaConfigOption
+from gremlin.ui.option import BaseMetaConfigOptionWidget, MetaConfigOption
 
 from gremlin.types import PropertyType
+
+
+class DummyWidget(BaseMetaConfigOptionWidget):
+
+    def _qml_path(self) -> str:
+        return "dummy.qml"
 
 
 def test_basic():
@@ -34,8 +40,8 @@ def test_basic():
 
     assert option.count() == 0
 
-    option.register("some", "test", "option 1", "description 1", "ui/test1.qml")
-    option.register("some", "test", "option 2", "description 2", "ui/test2.qml")
+    option.register("some", "test", "option 1", "description 1", DummyWidget)
+    option.register("some", "test", "option 2", "description 2", DummyWidget)
 
     assert option.count() == 2
 
@@ -44,8 +50,8 @@ def test_basic():
     assert len(option.entries("some", "test")) == 2
     assert option.description("some", "test", "option 1") == "description 1"
     assert option.description("some", "test", "option 2") == "description 2"
-    assert option.qml_element("some", "test", "option 1") == "ui/test1.qml"
-    assert option.qml_element("some", "test", "option 2") == "ui/test2.qml"
+    assert option.qml_widget("some", "test", "option 1") == DummyWidget
+    assert option.qml_widget("some", "test", "option 2") == DummyWidget
 
 
 def test_register_duplicate_logs_warning(caplog):
@@ -61,8 +67,8 @@ def test_register_duplicate_logs_warning(caplog):
 def test_retrieve_nonexistent_raises():
     option = MetaConfigOption()
     with pytest.raises(gremlin.error.GremlinError):
-        option.qml_element("no", "such", "option")
+        option.qml_widget("no", "such", "option")
 
-    option.register("sec", "grp", "name", "desc", "ui/elem.qml")
+    option.register("sec", "grp", "name", "desc", DummyWidget)
     with pytest.raises(gremlin.error.GremlinError):
         option.description("sec", "grp", "other")


### PR DESCRIPTION
This adds support for "meta options", i.e. things to show and configure in the Options dialog that don't have a 1:1 mapping to a basic type stored in the configuration system. This enables creating more complex interface elements configuring aspects of Gremlin while still fitting within the normal Option system.

This is then used for the action reordering and visibility setting option. This allows deciding the order of the actions in their drop down as well as which actions are shown at all.