### PR TITLE
Add device swap tool

### DIFF
--- a/action_plugins/condition/__init__.py
+++ b/action_plugins/condition/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, TYPE_CHECKING, override
+from typing import List, override, TYPE_CHECKING
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -332,5 +332,14 @@ class ConditionData(AbstractActionData):
         if old_behavior != new_behavior:
             for condition in self.conditions:
                 condition.set_input_type(new_behavior)
+
+    @override
+    def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
+        performed_swap = False
+        for condition in self.conditions:
+            if condition.swap_uuid(old_uuid, new_uuid):
+                performed_swap = True
+        return performed_swap
+
 
 create = ConditionData

--- a/action_plugins/condition/condition.py
+++ b/action_plugins/condition/condition.py
@@ -491,19 +491,20 @@ class JoystickCondition(AbstractCondition):
             input_type: InputType,
             input_id: int
         ) -> None:
-            self.device_uuid = device_uuid
+            self.device_uuid: uuid.UUID
             self.input_type = input_type
             self.input_id = input_id
             self.joystick = None
-            self.update_for_device()
+            self.initialize_for_uuid(device_uuid)
         
-        def update_for_device(self):
+        def initialize_for_uuid(self, device_uuid: uuid.UUID):
             try:
-                self.joystick = Joystick()[self.device_uuid]
+                self.joystick = Joystick()[device_uuid]
             except error.GremlinError:
                 pass
+            self.device_uuid = device_uuid
             self.device_lookup = DeviceDatabase().get_mapping_by_uuid(
-                self.device_uuid
+                device_uuid
             )
 
         def get(self) -> bool | float | HatDirection:
@@ -619,8 +620,7 @@ class JoystickCondition(AbstractCondition):
         performed_swap = False
         for state in self._states:
             if state.device_uuid == old_uuid:
-                state.device_uuid = new_uuid
-                state.update_for_device()
+                state.initialize_for_uuid(new_uuid)
                 performed_swap = True
         return performed_swap
 

--- a/action_plugins/dual_axis_deadzone/__init__.py
+++ b/action_plugins/dual_axis_deadzone/__init__.py
@@ -22,7 +22,7 @@ import collections
 import copy
 import logging
 import math
-from typing import Any, TYPE_CHECKING, override
+from typing import override, TYPE_CHECKING
 from xml.etree import ElementTree
 
 from PySide6 import QtCore, QtGui, QtQml
@@ -360,6 +360,17 @@ class DualAxisDeadzoneData(AbstractActionData):
             return self.output1_actions
         elif selector == "second":
             return self.output2_actions
+
+    @override
+    def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
+        performed_swap = False
+        if self.axis1.device_guid == old_uuid:
+            self.axis1.device_guid = new_uuid
+            performed_swap = True
+        if self.axis2.device_guid == old_uuid:
+            self.axis2.device_guid = new_uuid
+            performed_swap = True
+        return performed_swap
 
     @override
     def _handle_behavior_change(

--- a/action_plugins/macro/__init__.py
+++ b/action_plugins/macro/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import enum
 from itertools import count
-from typing import Any, List, Optional, TYPE_CHECKING, override
+from typing import Any, List, override, TYPE_CHECKING
 from unittest import case
 from xml.etree import ElementTree
 
@@ -909,6 +909,14 @@ class MacroData(AbstractActionData):
         new_behavior: InputType
     ) -> None:
         pass
+
+    @override
+    def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
+        performed_swap = False
+        for action in self.actions:
+            if action.swap_uuid(old_uuid, new_uuid):
+                performed_swap = True
+        return performed_swap
 
 
 create = MacroData

--- a/action_plugins/merge_axis/__init__.py
+++ b/action_plugins/merge_axis/__init__.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, TYPE_CHECKING, override
+from typing import override, TYPE_CHECKING
 import uuid
 from xml.etree import ElementTree
 

--- a/gremlin/macro.py
+++ b/gremlin/macro.py
@@ -23,7 +23,7 @@ import functools
 import logging
 import time
 from threading import Event, Lock, Thread
-from typing import Tuple
+from typing import override, Tuple
 import uuid
 from xml.etree import ElementTree
 
@@ -378,6 +378,10 @@ class AbstractAction(ABC):
         node.set("type", type_name)
         return node
 
+    def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
+        """Swaps occurrences of the old UUID with the new one for this action."""
+        return False
+
 
 class JoystickAction(AbstractAction):
 
@@ -494,6 +498,13 @@ class JoystickAction(AbstractAction):
             self.value = util.read_property(
                 node, "value", PropertyType.HatDirection
             )
+
+    @override
+    def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
+        if self.device_guid == old_uuid:
+            self.device_guid = new_uuid
+            return True
+        return False
 
 
 class KeyAction(AbstractAction):

--- a/gremlin/swap_devices.py
+++ b/gremlin/swap_devices.py
@@ -54,6 +54,9 @@ class SwapDevicesResult:
     action_swaps: int
     input_swaps: int
 
+    def as_string(self) -> str:
+        return f"Swapped {self.action_swaps} actions and {self.input_swaps} inputs."
+
 
 def _swap_device_inputs(
     profile: profile.Profile,

--- a/gremlin/swap_devices.py
+++ b/gremlin/swap_devices.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Performs a simple swap of two devices in the profile.
+"""
+
+import dataclasses
+import uuid
+
+from gremlin import device_initialization, profile
+
+
+@dataclasses.dataclass
+class ProfileDeviceInfo:
+    device_uuid: uuid.UUID
+    name: str = ""
+    num_bindings: int = 0
+
+
+def get_profile_devices(pr: profile.Profile) -> list[ProfileDeviceInfo]:
+    profile_devices = {}
+    for device_uuid, inputs in pr.inputs.items():
+        if device_uuid in profile_devices:
+            profile_devices[device_uuid].num_bindings += len(inputs)
+        else:
+            profile_devices[device_uuid] = ProfileDeviceInfo(
+                device_uuid, num_bindings=len(inputs)
+            )
+
+    # We can get names for connected devices (only).
+    for d in device_initialization.physical_devices():
+        if d.device_guid.uuid in profile_devices:
+            profile_devices[d.device_guid.uuid].name = d.name
+    return list(profile_devices.values())
+
+
+@dataclasses.dataclass
+class SwapDevicesResult:
+    action_swaps: int
+    input_swaps: int
+
+
+def _swap_device_inputs(
+    profile: profile.Profile,
+    source_device_uuid: uuid.UUID,
+    target_device_uuid: uuid.UUID,
+) -> int:
+    swap_count = 0
+    source_device_inputs = profile.inputs.get(source_device_uuid)
+    target_device_inputs = profile.inputs.get(target_device_uuid)
+
+    if source_device_inputs:
+        for input_item in source_device_inputs:
+            input_item.device_id = target_device_uuid
+            swap_count += 1
+        profile.inputs[target_device_uuid] = source_device_inputs
+    if target_device_inputs:
+        for input_item in target_device_inputs:
+            input_item.device_id = source_device_uuid
+            swap_count += 1
+        profile.inputs[source_device_uuid] = target_device_inputs
+    return swap_count
+
+
+def _swap_device_actions(
+    profile: profile.Profile,
+    source_device_uuid: uuid.UUID,
+    target_device_uuid: uuid.UUID,
+) -> int:
+    swap_count = 0
+    for action in profile.library.actions_by_predicate(lambda x: True):
+        swap_count += int(action.swap_uuid(source_device_uuid, target_device_uuid))
+    return swap_count
+
+
+def swap_devices(
+    profile: profile.Profile,
+    source_device_uuid: uuid.UUID,
+    target_device_uuid: uuid.UUID,
+) -> SwapDevicesResult:
+    """Swaps two devices in the profile (from a device in the profile to a connected device).
+
+    It is the caller's responsibility to ensure that the devices UUIDs are valid.
+
+    Args:
+        profile: The Profile to perform the swap on.
+        source_device_uuid: The UUID of the source (from profile) device.
+        target_device_uuid: The UUID of the target (connected) device.
+
+    Returns:
+        The SwapDevicesResult object containing stats on the swaps performed.
+    """
+    return SwapDevicesResult(
+        _swap_device_actions(profile, source_device_uuid, target_device_uuid),
+        _swap_device_inputs(profile, source_device_uuid, target_device_uuid),
+    )

--- a/gremlin/ui/backend.py
+++ b/gremlin/ui/backend.py
@@ -36,6 +36,7 @@ from gremlin.ui.auto_mapper import AutoMapper
 from gremlin.ui.device import InputIdentifier, LogicalDeviceManagementModel
 from gremlin.ui.profile import InputItemModel, ModeHierarchyModel
 from gremlin.ui.script import ScriptListModel
+from gremlin.ui.swap_devices import SwapDevices
 from gremlin.audio_player import AudioPlayer
 
 
@@ -334,6 +335,10 @@ class Backend(QtCore.QObject):
     @Slot(result=AutoMapper)
     def getAutoMapper(self) -> AutoMapper:
         return AutoMapper(self)
+
+    @Slot(result=SwapDevices)
+    def getSwapDevices(self) -> SwapDevices:
+        return SwapDevices(self)
 
     @Slot(str, int, result=bool)
     def isActionExpanded(self, uuid_str: str, index: int) -> bool:

--- a/gremlin/ui/backend.py
+++ b/gremlin/ui/backend.py
@@ -28,15 +28,13 @@ from PySide6.QtCore import Property, Signal, Slot
 import dill
 
 from gremlin import code_runner, common, config, device_initialization, error, \
-    event_handler, mode_manager, profile, shared_state, types
+    event_handler, mode_manager, profile, shared_state
 from gremlin.logical_device import LogicalDevice
 from gremlin.signal import signal
 
-from gremlin.ui.auto_mapper import AutoMapper
 from gremlin.ui.device import InputIdentifier, LogicalDeviceManagementModel
 from gremlin.ui.profile import InputItemModel, ModeHierarchyModel
 from gremlin.ui.script import ScriptListModel
-from gremlin.ui.swap_devices import SwapDevices
 from gremlin.audio_player import AudioPlayer
 
 
@@ -331,14 +329,6 @@ class Backend(QtCore.QObject):
     @Slot(result=LogicalDeviceManagementModel)
     def getLogicalDeviceManagementModel(self) -> LogicalDeviceManagementModel:
         return LogicalDeviceManagementModel(self)
-    
-    @Slot(result=AutoMapper)
-    def getAutoMapper(self) -> AutoMapper:
-        return AutoMapper(self)
-
-    @Slot(result=SwapDevices)
-    def getSwapDevices(self) -> SwapDevices:
-        return SwapDevices(self)
 
     @Slot(str, int, result=bool)
     def isActionExpanded(self, uuid_str: str, index: int) -> bool:

--- a/gremlin/ui/device.py
+++ b/gremlin/ui/device.py
@@ -186,15 +186,14 @@ class DeviceListModel(QtCore.QAbstractListModel):
         self.rowsRemoved.emit(self.parent(), 0, new_count)
         self.rowsInserted.emit(self.parent(), 0, new_count)
     
-    @QtCore.Property(int)
+    @QtCore.Property(int, notify=selectedIndexChanged)
     def selectedIndex(self):
         return self._selected_index
         
     @selectedIndex.setter
     def selectedIndex(self, index):
-        if 0 <= index < len(self._devices):
+        if 0 <= index < len(self._devices) and index != self._selected_index:
             self._selected_index = index
-            self.selectedIndexChanged.emit()
 
     deviceType = Property(
         str,

--- a/gremlin/ui/profile_devices_model.py
+++ b/gremlin/ui/profile_devices_model.py
@@ -17,13 +17,21 @@
 
 from typing import Any
 
-from PySide6 import QtCore
-from PySide6 import QtQml
+from PySide6 import (
+    QtCore,
+    QtQml,
+)
 
 import dill
-from gremlin import event_handler, swap_devices
+from gremlin import (
+    event_handler,
+    swap_devices,
+)
 from gremlin.error import GremlinError
-from gremlin.ui import backend
+from gremlin.ui import (
+    backend,
+    type_aliases,
+)
 
 QML_IMPORT_NAME = "Gremlin.Tools"
 QML_IMPORT_MAJOR_VERSION = 1
@@ -53,19 +61,18 @@ class ProfileDeviceListModel(QtCore.QAbstractListModel):
         # Ensure the entire model is refreshed
         self.modelReset.emit()
 
-    def rowCount(self, parent: QtCore.QModelIndex = ...) -> int:
+    def rowCount(self, parent: type_aliases.MI = QtCore.QModelIndex()) -> int:
         return len(self._devices)
 
     def data(
-        self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole
+        self, index: type_aliases.MI, role: int = QtCore.Qt.DisplayRole
     ) -> Any:
         if not index.isValid() or not (0 <= index.row() < len(self._devices)):
             return None
 
         device = self._devices[index.row()]
-        if role in ProfileDeviceListModel.roles:
-            role_name = ProfileDeviceListModel.roles[role].data().decode()
-            match role_name:
+        if role in self.roles:
+            match self.roles[role]:
                 case "name":
                     return device.name
                 case "uuid":
@@ -75,7 +82,7 @@ class ProfileDeviceListModel(QtCore.QAbstractListModel):
         raise ValueError(f"Unknown {role=}")
         
     def roleNames(self) -> dict[int, QtCore.QByteArray]:
-        return ProfileDeviceListModel.roles
+        return self.roles
 
     @QtCore.Slot(int, result=str)
     def uuidAtIndex(self, index: int) -> str:
@@ -86,12 +93,12 @@ class ProfileDeviceListModel(QtCore.QAbstractListModel):
 
         return str(self._devices[index].device_uuid)
     
-    @QtCore.Property(int)
+    @QtCore.Property(int, notify=selectedIndexChanged)
     def selectedIndex(self):
         return self._selected_index
     
     @selectedIndex.setter
     def selectedIndex(self, index):
-        if 0 <= index < len(self._devices):
+        if 0 <= index < len(self._devices) and index != self._selected_index:
             self._selected_index = index
-            self.selectedIndexChanged.emit()
+        self.selectedIndexChanged.emit()

--- a/gremlin/ui/profile_devices_model.py
+++ b/gremlin/ui/profile_devices_model.py
@@ -15,15 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 from typing import Any
-import uuid
 
 from PySide6 import QtCore
 from PySide6 import QtQml
 
 import dill
 from gremlin import event_handler, swap_devices
+from gremlin.error import GremlinError
 from gremlin.ui import backend
 
 QML_IMPORT_NAME = "Gremlin.Tools"
@@ -83,7 +82,7 @@ class ProfileDeviceListModel(QtCore.QAbstractListModel):
         if len(self._devices) == 0:
             return str(dill.UUID_Invalid)
         if not (0 <= index < len(self._devices)):
-            raise GremlinError("Provided index out of range")
+            raise GremlinError(f"Provided {index=} out of range")
 
         return str(self._devices[index].device_uuid)
     
@@ -96,31 +95,3 @@ class ProfileDeviceListModel(QtCore.QAbstractListModel):
         if 0 <= index < len(self._devices):
             self._selected_index = index
             self.selectedIndexChanged.emit()
-
-
-@QtQml.QmlElement
-class SwapDevices(QtCore.QObject):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-    @QtCore.Slot(str, str, result=str)
-    def swapDevices(self, source_device_uuid: str, target_device_uuid: str) -> str:
-        """
-        Swaps the specified two devices in the profile.
-
-        Args:
-            source_device_uuid: The UUID of the source (from profile) device.
-            target_device_uuid: The UUID of the target (connected) device.
-
-        Returns:
-            The number of action and input swaps performed.
-        """
-        logging.getLogger("system").info(
-            f"Swapping devices {source_device_uuid} and {target_device_uuid}"
-        )
-        result = swap_devices.swap_devices(
-            backend.Backend().profile,
-            uuid.UUID(source_device_uuid),
-            uuid.UUID(target_device_uuid),
-        )
-        return result.as_string()

--- a/gremlin/ui/swap_devices.py
+++ b/gremlin/ui/swap_devices.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import uuid
+
+from PySide6 import QtCore
+from PySide6 import QtQml
+
+import dill
+from gremlin import event_handler, swap_devices
+from gremlin.ui import backend
+
+QML_IMPORT_NAME = "Gremlin.Tools"
+QML_IMPORT_MAJOR_VERSION = 1
+
+
+@QtQml.QmlElement
+class ProfileDeviceListModel(QtCore.QAbstractListModel):
+    """Model listing devices with bindings in the profile."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._devices: list[swap_devices.ProfileDeviceInfo] = []
+        self.update_model()
+        event_handler.EventListener().device_change_event.connect(self.update_model)
+
+    def update_model(self) -> None:
+        """Updates the model if the connected devices change."""
+        self._devices = swap_devices.get_profile_devices(backend.Backend().profile)
+        # Ensure the entire model is refreshed
+        self.modelReset.emit()
+
+    def rowCount(self, parent: QtCore.QModelIndex = ...) -> int:
+        return len(self._devices)
+
+    def data(
+        self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole
+    ) -> swap_devices.ProfileDeviceInfo | None:
+        if not index.isValid() or not (0 <= index.row() < len(self._devices)):
+            return None
+        device = self._devices[index.row()]
+        if role == QtCore.Qt.DisplayRole:
+            if device.name:
+                return f"{device.name}: {device.num_bindings} bindings"
+            return f"{device.device_uuid}: {device.num_bindings} bindings"
+        return None
+
+    @QtCore.Slot(int, result=str)
+    def uuidAtIndex(self, index: int) -> str:
+        if len(self._devices) == 0:
+            return str(dill.UUID_Invalid)
+        if not (0 <= index < len(self._devices)):
+            raise GremlinError("Provided index out of range")
+
+        return str(self._devices[index].device_uuid)
+
+
+@QtQml.QmlElement
+class SwapDevices(QtCore.QObject):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    @QtCore.Slot(str, str, result=str)
+    def swapDevices(self, source_device_uuid: str, target_device_uuid: str) -> str:
+        """
+        Swaps the specified two devices in the profile.
+
+        Args:
+            source_device_uuid: The UUID of the source (from profile) device.
+            target_device_uuid: The UUID of the target (connected) device.
+
+        Returns:
+            The number of action and input swaps performed.
+        """
+        logging.getLogger("system").info(
+            f"Swapping devices {source_device_uuid} and {target_device_uuid}"
+        )
+        result = swap_devices.swap_devices(
+            backend.Backend().profile,
+            uuid.UUID(source_device_uuid),
+            uuid.UUID(target_device_uuid),
+        )
+        return result.as_string()

--- a/gremlin/ui/tools.py
+++ b/gremlin/ui/tools.py
@@ -16,20 +16,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import uuid
 
 from PySide6 import QtCore
 from PySide6 import QtQml
 
 import dill
-from gremlin import auto_mapper
+from gremlin import auto_mapper, swap_devices
 from gremlin.ui import backend
+from gremlin.ui.profile_devices_model import ProfileDeviceListModel
 
 QML_IMPORT_NAME = "Gremlin.Tools"
 QML_IMPORT_MAJOR_VERSION = 1
 
 
 @QtQml.QmlElement
-class AutoMapper(QtCore.QObject):
+class Tools(QtCore.QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -63,3 +65,25 @@ class AutoMapper(QtCore.QObject):
             [int(vjoy_id) for (vjoy_id, chosen) in vjoy_devices.items() if chosen],
             auto_mapper.AutoMapperOptions(mode, repeat, overwrite),
         )
+
+    @QtCore.Slot(str, str, result=str)
+    def swapDevices(self, source_device_uuid: str, target_device_uuid: str) -> str:
+        """
+        Swaps the specified two devices in the profile.
+
+        Args:
+            source_device_uuid: The UUID of the source (from profile) device.
+            target_device_uuid: The UUID of the target (connected) device.
+
+        Returns:
+            The number of action and input swaps performed.
+        """
+        logging.getLogger("system").info(
+            f"Swapping devices {source_device_uuid} and {target_device_uuid}"
+        )
+        result = swap_devices.swap_devices(
+            backend.Backend().profile,
+            uuid.UUID(source_device_uuid),
+            uuid.UUID(target_device_uuid),
+        )
+        return result.as_string()

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -69,6 +69,7 @@ import gremlin.signal
 
 import gremlin.ui.backend
 import gremlin.ui.option
+import gremlin.ui.tools
 import gremlin.ui.util
 
 

--- a/qml/DialogAutoMapper.qml
+++ b/qml/DialogAutoMapper.qml
@@ -44,8 +44,8 @@ Window {
         deviceType: "virtual"
     }
 
-    AutoMapper {
-        id: autoMapper
+    Tools {
+        id: tools
     }
 
     // Properties to track the selected devices and user selections.
@@ -192,7 +192,7 @@ Window {
                 Layout.preferredWidth: implicitWidth + 20
                 Layout.preferredHeight: 30
                 onClicked: {
-                    statusMessage = autoMapper.createMappings(
+                    statusMessage = tools.createMappings(
                         selectedMode,
                         selectedPhysicalDevices, selectedVJoyDevices,
                         overwriteNonEmpty, repeatVJoy);

--- a/qml/DialogSwapDevices.qml
+++ b/qml/DialogSwapDevices.qml
@@ -47,10 +47,6 @@ Window {
         id: swapDevices
     }
 
-    // Properties to track the selected devices.
-    property var selectedTargetDevice: ""
-    property var selectedSourceDevice: ""
-
     property string statusMessage: "Select devices, and click the Swap Bindings button"
 
     ColumnLayout {
@@ -85,10 +81,7 @@ Window {
                     model: physicalDevices
                     textRole: "name"
                     Layout.fillWidth: true
-                    onActivated: selectedTargetDevice = physicalDevices.guidAtIndex(currentIndex)
-                    Component.onCompleted: {
-                        selectedTargetDevice = physicalDevices.guidAtIndex(0) || ""
-                    }
+                    onActivated: physicalDevices.selectedIndex = currentIndex
                 }
             }
 
@@ -100,13 +93,14 @@ Window {
                 }
                 
                 ComboBox {
-                    id: secondDeviceCombo
                     model: profileDevices
-                    textRole: "display"
+                    textRole: "uuid"
                     Layout.fillWidth: true
-                    onActivated: selectedSourceDevice = profileDevices.uuidAtIndex(currentIndex)
-                    Component.onCompleted: {
-                        selectedSourceDevice = profileDevices.uuidAtIndex(0) || ""
+                    onActivated: profileDevices.selectedIndex = currentIndex
+
+                    delegate: ItemDelegate {
+                        width: parent.width
+                        text: `${model.name || model.uuid}: ${model.numBindings} ${model.numBindings === 1 ? 'binding' : 'bindings'}`
                     }
                 }
             }
@@ -121,7 +115,8 @@ Window {
                 text: qsTr("Swap Bindings")
                 onClicked: {
                     statusMessage = swapDevices.swapDevices(
-                        selectedSourceDevice, selectedTargetDevice);
+                        profileDevices.uuidAtIndex(profileDevices.selectedIndex),
+                        physicalDevices.uuidAtIndex(physicalDevices.selectedIndex));
                 }
             }
 

--- a/qml/DialogSwapDevices.qml
+++ b/qml/DialogSwapDevices.qml
@@ -1,0 +1,136 @@
+// -*- coding: utf-8; -*-
+//
+// Copyright (C) 2015 - 2025 Lionel Ott
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+
+import QtQuick.Controls.Universal
+
+import Gremlin.Device
+import Gremlin.Profile
+import Gremlin.Tools
+
+
+Window {
+    minimumWidth: 900
+    minimumHeight: 300
+
+    title: "Swap devices: Swaps bindings between two devices"
+
+    DeviceListModel {
+        id: physicalDevices
+        deviceType: "physical"
+    }
+
+    ProfileDeviceListModel {
+        id: profileDevices
+    }
+
+    SwapDevices {
+        id: swapDevices
+    }
+
+    // Properties to track the selected devices.
+    property var selectedTargetDevice: ""
+    property var selectedSourceDevice: ""
+
+    property string statusMessage: "Select devices, and click the Swap Bindings button"
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 10
+
+        // Description/Manual Section
+        TextOutputBox {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 100
+            text: qsTr("<ul>" +
+                    "<li>Select the devices to swap bindings between" +
+                    "<li>Click 'Swap' to swap the bindings between the selected devices" +
+                    "<li>Resulting bindings may be invalid if devices have different numbers " +
+                    "of inputs" +
+                    "</ul>")
+        }
+
+        // Main content area with device dropdowns.
+        RowLayout {
+            spacing: 10
+
+            // First ("Connected") Device Column
+            ColumnLayout {
+                Label {
+                    text: qsTr("Select connected device")
+                    font.bold: true
+                }
+                
+                ComboBox {
+                    id: firstDeviceCombo
+                    model: physicalDevices
+                    textRole: "name"
+                    Layout.fillWidth: true
+                    onActivated: selectedTargetDevice = physicalDevices.guidAtIndex(currentIndex)
+                    Component.onCompleted: {
+                        selectedTargetDevice = physicalDevices.guidAtIndex(0) || ""
+                    }
+                }
+            }
+
+            // Second ("Profile") Device Column
+            ColumnLayout {
+                Label {
+                    text: qsTr("Select device in profile")
+                    font.bold: true
+                }
+                
+                ComboBox {
+                    id: secondDeviceCombo
+                    model: profileDevices
+                    textRole: "display"
+                    Layout.fillWidth: true
+                    onActivated: selectedSourceDevice = profileDevices.uuidAtIndex(currentIndex)
+                    Component.onCompleted: {
+                        selectedSourceDevice = profileDevices.uuidAtIndex(0) || ""
+                    }
+                }
+            }
+        }
+
+        // Action bar with button and status
+        RowLayout {
+            spacing: 10
+
+            Button {
+                id: _swapButton
+                text: qsTr("Swap Bindings")
+                onClicked: {
+                    statusMessage = swapDevices.swapDevices(
+                        selectedSourceDevice, selectedTargetDevice);
+                }
+            }
+
+            TextOutputBox {
+                id: _statusNotification
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                text: statusMessage
+            }
+        }
+    }
+}

--- a/qml/DialogSwapDevices.qml
+++ b/qml/DialogSwapDevices.qml
@@ -43,8 +43,8 @@ Window {
         id: profileDevices
     }
 
-    SwapDevices {
-        id: swapDevices
+    Tools {
+        id: tools
     }
 
     property string statusMessage: "Select devices, and click the Swap Bindings button"
@@ -82,6 +82,7 @@ Window {
                     textRole: "name"
                     Layout.fillWidth: true
                     onActivated: physicalDevices.selectedIndex = currentIndex
+                    Component.onCompleted: physicalDevices.selectedIndex = currentIndex
                 }
             }
 
@@ -97,6 +98,7 @@ Window {
                     textRole: "uuid"
                     Layout.fillWidth: true
                     onActivated: profileDevices.selectedIndex = currentIndex
+                    Component.onCompleted: profileDevices.selectedIndex = currentIndex
 
                     delegate: ItemDelegate {
                         width: parent.width
@@ -114,7 +116,7 @@ Window {
                 id: _swapButton
                 text: qsTr("Swap Bindings")
                 onClicked: {
-                    statusMessage = swapDevices.swapDevices(
+                    statusMessage = tools.swapDevices(
                         profileDevices.uuidAtIndex(profileDevices.selectedIndex),
                         physicalDevices.uuidAtIndex(physicalDevices.selectedIndex));
                 }

--- a/qml/DialogSwapDevices.qml
+++ b/qml/DialogSwapDevices.qml
@@ -35,16 +35,16 @@ Window {
     title: "Swap devices: Swaps bindings between two devices"
 
     DeviceListModel {
-        id: physicalDevices
+        id: _physicalDevices
         deviceType: "physical"
     }
 
     ProfileDeviceListModel {
-        id: profileDevices
+        id: _profileDevices
     }
 
     Tools {
-        id: tools
+        id: _tools
     }
 
     property string statusMessage: "Select devices, and click the Swap Bindings button"
@@ -77,12 +77,11 @@ Window {
                 }
                 
                 ComboBox {
-                    id: firstDeviceCombo
-                    model: physicalDevices
+                    model: _physicalDevices
                     textRole: "name"
                     Layout.fillWidth: true
-                    onActivated: physicalDevices.selectedIndex = currentIndex
-                    Component.onCompleted: physicalDevices.selectedIndex = currentIndex
+                    onActivated: _physicalDevices.selectedIndex = currentIndex
+                    Component.onCompleted: _physicalDevices.selectedIndex = currentIndex
                 }
             }
 
@@ -94,11 +93,11 @@ Window {
                 }
                 
                 ComboBox {
-                    model: profileDevices
+                    model: _profileDevices
                     textRole: "uuid"
                     Layout.fillWidth: true
-                    onActivated: profileDevices.selectedIndex = currentIndex
-                    Component.onCompleted: profileDevices.selectedIndex = currentIndex
+                    onActivated: _profileDevices.selectedIndex = currentIndex
+                    Component.onCompleted: _profileDevices.selectedIndex = currentIndex
 
                     delegate: ItemDelegate {
                         width: parent.width
@@ -113,17 +112,15 @@ Window {
             spacing: 10
 
             Button {
-                id: _swapButton
                 text: qsTr("Swap Bindings")
                 onClicked: {
-                    statusMessage = tools.swapDevices(
-                        profileDevices.uuidAtIndex(profileDevices.selectedIndex),
-                        physicalDevices.uuidAtIndex(physicalDevices.selectedIndex));
+                    statusMessage = _tools.swapDevices(
+                        _profileDevices.uuidAtIndex(_profileDevices.selectedIndex),
+                        _physicalDevices.uuidAtIndex(_physicalDevices.selectedIndex));
                 }
             }
 
             TextOutputBox {
-                id: _statusNotification
                 Layout.fillWidth: true
                 Layout.preferredHeight: 30
                 text: statusMessage

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -155,6 +155,10 @@ ApplicationWindow {
                 onTriggered: Helpers.createComponent("DialogAutoMapper.qml")
             }
             MenuItem {
+                text: qsTr("Swap Devices")
+                onTriggered: Helpers.createComponent("DialogSwapDevices.qml")
+            }
+            MenuItem {
                 text: qsTr("Device Information")
                 onTriggered: Helpers.createComponent("DialogDeviceInformation.qml")
             }

--- a/test/unit/test_action_dual_axis_deadzone.py
+++ b/test/unit/test_action_dual_axis_deadzone.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import pathlib
+import uuid
+from gremlin.profile import Profile
+from action_plugins import dual_axis_deadzone, map_to_vjoy
+
+_PROFILE = "action_dual_axis_deadzone.xml"
+_ACTION_UUID = uuid.UUID("20465c1e-afb3-49f9-9e43-1d7087f0e8ce")
+_INPUT_1_DEVICE_UUID = uuid.UUID("97b77b40-07d8-11f0-8028-444553540000")
+_INPUT_2_DEVICE_UUID = uuid.UUID("97b77b40-07d8-11f0-8028-444553540001")
+
+
+def test_from_xml(subtests, xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / _PROFILE))
+
+    a = p.library.get_action(_ACTION_UUID)
+
+    assert isinstance(a, dual_axis_deadzone.DualAxisDeadzoneData)
+    with subtests.test("action inputs"):
+        assert a.inner_deadzone == 0.0
+        assert a.outer_deadzone == 1.0
+        assert a.axis1.device_guid == _INPUT_1_DEVICE_UUID
+        assert a.axis1.input_id == 1
+        assert a.axis2.device_guid == _INPUT_2_DEVICE_UUID
+        assert a.axis2.input_id == 2
+        assert a.is_valid()
+
+    with subtests.test("action outputs"):
+        assert len(a.output1_actions) == 1
+        assert len(a.output2_actions) == 1
+        assert isinstance(a.output1_actions[0], map_to_vjoy.MapToVjoyData)
+        assert a.output1_actions[0].vjoy_device_id == 1
+        assert a.output1_actions[0].vjoy_input_id == 1
+        assert isinstance(a.output2_actions[0], map_to_vjoy.MapToVjoyData)
+        assert a.output2_actions[0].vjoy_device_id == 1
+        assert a.output2_actions[0].vjoy_input_id == 2
+
+
+def test_swap_uuid(xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / _PROFILE))
+
+    a = p.library.get_action(_ACTION_UUID)
+
+    new_device_uuid = uuid.uuid4()
+    a.swap_uuid(_INPUT_1_DEVICE_UUID, new_device_uuid)
+    assert a.axis1.device_guid == new_device_uuid
+    assert a.axis2.device_guid == _INPUT_2_DEVICE_UUID
+    

--- a/test/unit/test_action_macro.py
+++ b/test/unit/test_action_macro.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import pathlib
+import uuid
+from gremlin.profile import Profile
+from action_plugins import macro
+
+_PROFILE = "action_macro.xml"
+_ACTION_UUID = uuid.UUID("8759f48d-8879-488a-9895-07503bf0dc0c")
+_INPUT_1_DEVICE_UUID = uuid.UUID("97b77b40-07d8-11f0-8028-444553540000")
+_INPUT_2_DEVICE_UUID = uuid.UUID("97b77b40-07d8-11f0-8028-444553540001")
+
+
+def test_from_xml(subtests, xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / _PROFILE))
+
+    a = p.library.get_action(_ACTION_UUID)
+
+    assert isinstance(a, macro.MacroData)
+    with subtests.test("macro high level data"):
+        assert a.is_exclusive == False
+        assert a.repeat_mode == macro.MacroRepeatModes.Single
+        assert a.repeat_data.count == 1
+        assert a.repeat_data.delay == 0.1
+        assert a.is_valid()
+        assert len(a.actions) == 10
+
+
+def test_swap_uuid(xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / _PROFILE))
+
+    a = p.library.get_action(_ACTION_UUID)
+
+    new_device_uuid = uuid.uuid4()
+    assert a.swap_uuid(_INPUT_1_DEVICE_UUID, new_device_uuid)
+    assert a.actions[0].device_guid == new_device_uuid
+    assert a.actions[2].device_guid == _INPUT_2_DEVICE_UUID
+    

--- a/test/unit/test_action_merge.py
+++ b/test/unit/test_action_merge.py
@@ -23,6 +23,12 @@ import pytest
 import uuid
 from xml.etree import ElementTree
 
+# Test UUIDs
+_ACTION_ID = uuid.UUID("ac905a47-9ad3-4b65-b702-fbae1d133609")
+_DESCRIPTION_ID = uuid.UUID("fbe6be7b-07c9-4400-94f2-caa245ebcc7e")
+_DEVICE_GUID_1 = uuid.UUID("4DCB3090-97EC-11EB-8003-444553540001")
+_DEVICE_GUID_2 = uuid.UUID("4DCB3090-97EC-11EB-8003-444553540002")
+
 from gremlin.types import DataInsertionMode
 from gremlin.error import GremlinError
 from gremlin.profile import Library, Profile
@@ -47,31 +53,31 @@ def test_from_xml(xml_dir: pathlib.Path):
     p = Profile()
     p.from_xml(str(xml_dir / "action_merge_axis.xml"))
 
-    a = p.library.get_action(uuid.UUID("ac905a47-9ad3-4b65-b702-fbae1d133609"))
+    a = p.library.get_action(_ACTION_ID)
 
     assert len(a.children) == 1
     assert a.label == "test axis merge"
     assert a.operation == merge_axis.MergeOperation.Minimum
-    assert a.axis_in1.device_guid == uuid.UUID("4DCB3090-97EC-11EB-8003-444553540001")
+    assert a.axis_in1.device_guid == _DEVICE_GUID_1
     assert a.axis_in1.input_type == types.InputType.JoystickAxis
     assert a.axis_in1.input_id == 1
-    assert a.axis_in2.device_guid == uuid.UUID("4DCB3090-97EC-11EB-8003-444553540002")
+    assert a.axis_in2.device_guid == _DEVICE_GUID_2
     assert a.axis_in2.input_type == types.InputType.JoystickAxis
     assert a.axis_in2.input_id ==  2
 
 
 def test_to_xml():
     d = DescriptionData()
-    d._id = uuid.UUID("fbe6be7b-07c9-4400-94f2-caa245ebcc7e")
+    d._id = _DESCRIPTION_ID
 
     a = merge_axis.MergeAxisData(types.InputType.JoystickAxis)
     a.label = "This is a test"
     a.operation = merge_axis.MergeOperation.Maximum
     a.insert_action(d, "children")
 
-    a.axis_in1.device_guid = uuid.UUID("4DCB3090-97EC-11EB-8003-444553540001")
+    a.axis_in1.device_guid = _DEVICE_GUID_1
     a.axis_in1.input_type = types.InputType.JoystickAxis
-    a.axis_in2.device_guid = uuid.UUID("4DCB3090-97EC-11EB-8003-444553540002")
+    a.axis_in2.device_guid = _DEVICE_GUID_2
     a.axis_in1.input_id = 1
     a.axis_in2.input_type = types.InputType.JoystickAxis
     a.axis_in2.input_id =  2
@@ -86,6 +92,29 @@ def test_to_xml():
     assert node.find(
             "./property/name[.='axis1-axis']/../value"
         ).text == "1"
-    assert node.find(
-        "./property/name[.='axis1-guid']/../value"
-    ).text.upper() == "4DCB3090-97EC-11EB-8003-444553540001"
+    assert (
+        node.find("./property/name[.='axis1-guid']/../value").text.upper()
+        == str(_DEVICE_GUID_1).upper()
+    )
+
+
+def test_swap_first_uuid(xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / "action_merge_axis.xml"))
+
+    a = p.library.get_action(_ACTION_ID)
+    new_device_uuid = uuid.uuid4()
+    a.swap_uuid(_DEVICE_GUID_1, new_device_uuid)
+    assert a.axis_in1.device_guid == new_device_uuid
+    assert a.axis_in2.device_guid == _DEVICE_GUID_2
+
+
+def test_swap_second_uuid(xml_dir: pathlib.Path):
+    p = Profile()
+    p.from_xml(str(xml_dir / "action_merge_axis.xml"))
+
+    a = p.library.get_action(_ACTION_ID)
+    new_device_uuid = uuid.uuid4()
+    a.swap_uuid(_DEVICE_GUID_2, new_device_uuid)
+    assert a.axis_in1.device_guid == _DEVICE_GUID_1
+    assert a.axis_in2.device_guid == new_device_uuid

--- a/test/unit/test_swap_devices.py
+++ b/test/unit/test_swap_devices.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; -*-
+
+# Copyright (C) 2015 - 2025 Lionel Ott
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+import uuid
+
+from gremlin import profile, swap_devices
+
+_PROFILE_DEVICE_UUID = uuid.UUID('97b77b40-07d8-11f0-8028-444553540000')
+
+
+def test_swap_devices_from_data_xml(xml_dir: pathlib.Path):
+    p = profile.Profile()
+    existing_uuid = _PROFILE_DEVICE_UUID
+    new_uuid = uuid.uuid4()
+    p.from_xml(str(xml_dir / "profile_auto_mapper.xml"))
+    result = swap_devices.swap_devices(p, existing_uuid, new_uuid)
+    assert result.input_swaps == 9
+    assert result.action_swaps == 2

--- a/test/unit/test_swap_devices.py
+++ b/test/unit/test_swap_devices.py
@@ -18,16 +18,17 @@
 import pathlib
 import uuid
 
-from gremlin import profile, swap_devices
+import gremlin.profile
+from gremlin import swap_devices
 
 _PROFILE_DEVICE_UUID = uuid.UUID('97b77b40-07d8-11f0-8028-444553540000')
 
 
 def test_swap_devices_from_data_xml(xml_dir: pathlib.Path):
-    p = profile.Profile()
+    profile = gremlin.profile.Profile()
     existing_uuid = _PROFILE_DEVICE_UUID
     new_uuid = uuid.uuid4()
-    p.from_xml(str(xml_dir / "profile_auto_mapper.xml"))
-    result = swap_devices.swap_devices(p, existing_uuid, new_uuid)
+    profile.from_xml(str(xml_dir / "profile_auto_mapper.xml"))
+    result = swap_devices.swap_devices(profile, existing_uuid, new_uuid)
     assert result.input_swaps == 9
     assert result.action_swaps == 2

--- a/test/unit/test_user_script.py
+++ b/test/unit/test_user_script.py
@@ -17,6 +17,7 @@
 
 import pathlib
 import pytest
+import uuid
 
 from gremlin import profile, shared_state, types, user_script
 from test.unit.conftest import get_fake_device_guid
@@ -359,3 +360,17 @@ class TestScript:
             var_from_xml.from_xml(var.to_xml())
             assert var_from_xml.is_valid()
             assert var_from_xml.value == var.value
+
+    def test_swap_uuid(self, script_for_test: user_script.Script):
+        var = script_for_test.get_variable("A physical axis input variable")
+        existing_device_uuid = get_fake_device_guid(is_virtual=False).uuid
+        var.value = (
+            existing_device_uuid,
+            types.InputType.JoystickAxis,
+            1,
+        )
+        assert var.is_valid()
+        assert var.value[0] == existing_device_uuid
+        new_device_uuid = uuid.uuid4()
+        assert script_for_test.swap_uuid(existing_device_uuid, new_device_uuid)
+        assert var.value[0] == new_device_uuid

--- a/test/unit/xml/action_dual_axis_deadzone.xml
+++ b/test/unit/xml/action_dual_axis_deadzone.xml
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" ?>
+<profile version="14">
+    <library>
+        <action id="8a089715-2007-4612-955f-20b9763402a4" type="root">
+            <actions>
+                <action-id>20465c1e-afb3-49f9-9e43-1d7087f0e8ce</action-id>
+            </actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Root</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+        <action id="20465c1e-afb3-49f9-9e43-1d7087f0e8ce" type="dual-axis-deadzone">
+            <property type="string">
+                <name>label</name>
+                <value/>
+            </property>
+            <property type="float">
+                <name>inner-deadzone</name>
+                <value>0.0</value>
+            </property>
+            <property type="float">
+                <name>outer-deadzone</name>
+                <value>1.0</value>
+            </property>
+            <property type="uuid">
+                <name>axis1-guid</name>
+                <value>97b77b40-07d8-11f0-8028-444553540000</value>
+            </property>
+            <property type="int">
+                <name>axis1-axis</name>
+                <value>1</value>
+            </property>
+            <property type="uuid">
+                <name>axis2-guid</name>
+                <value>97b77b40-07d8-11f0-8028-444553540001</value>
+            </property>
+            <property type="int">
+                <name>axis2-axis</name>
+                <value>2</value>
+            </property>
+            <output1-actions>
+                <action-id>ff520daf-1c55-4da0-aedf-c08c101c0996</action-id>
+            </output1-actions>
+            <output2-actions>
+                <action-id>2899b1c3-0466-409f-a9bf-fa710bf70451</action-id>
+            </output2-actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Dual Axis Deadzone</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+        <action id="ff520daf-1c55-4da0-aedf-c08c101c0996" type="map-to-vjoy">
+            <property type="int">
+                <name>vjoy-device-id</name>
+                <value>1</value>
+            </property>
+            <property type="int">
+                <name>vjoy-input-id</name>
+                <value>1</value>
+            </property>
+            <property type="input_type">
+                <name>vjoy-input-type</name>
+                <value>axis</value>
+            </property>
+            <property type="axis_mode">
+                <name>axis-mode</name>
+                <value>absolute</value>
+            </property>
+            <property type="float">
+                <name>axis-scaling</name>
+                <value>1.0</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value>Map to vJoy</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>both</value>
+            </property>
+        </action>
+        <action id="2899b1c3-0466-409f-a9bf-fa710bf70451" type="map-to-vjoy">
+            <property type="int">
+                <name>vjoy-device-id</name>
+                <value>1</value>
+            </property>
+            <property type="int">
+                <name>vjoy-input-id</name>
+                <value>2</value>
+            </property>
+            <property type="input_type">
+                <name>vjoy-input-type</name>
+                <value>axis</value>
+            </property>
+            <property type="axis_mode">
+                <name>axis-mode</name>
+                <value>absolute</value>
+            </property>
+            <property type="float">
+                <name>axis-scaling</name>
+                <value>1.0</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value>Map to vJoy</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>both</value>
+            </property>
+        </action>
+    </library>
+    <modes>
+        <mode>Default</mode>
+    </modes>
+    <scripts/>
+</profile>

--- a/test/unit/xml/action_macro.xml
+++ b/test/unit/xml/action_macro.xml
@@ -1,0 +1,184 @@
+﻿<?xml version="1.0" ?>
+<profile version="14">
+    <library>
+        <action id="8759f48d-8879-488a-9895-07503bf0dc0c" type="macro">
+            <property type="bool">
+                <name>is-exclusive</name>
+                <value>False</value>
+            </property>
+            <property type="string">
+                <name>repeat-mode</name>
+                <value>Single</value>
+            </property>
+            <property type="int">
+                <name>repeat-count</name>
+                <value>1</value>
+            </property>
+            <property type="float">
+                <name>repeat-delay</name>
+                <value>0.1</value>
+            </property>
+            <macro-action type="joystick">
+                <property type="uuid">
+                    <name>device-guid</name>
+                    <value>97b77b40-07d8-11f0-8028-444553540000</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>button</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>2</value>
+                </property>
+                <property type="bool">
+                    <name>value</name>
+                    <value>True</value>
+                </property>
+            </macro-action>
+            <macro-action type="pause">
+                <property type="float">
+                    <name>duration</name>
+                    <value>0.5</value>
+                </property>
+            </macro-action>
+            <macro-action type="joystick">
+                <property type="uuid">
+                    <name>device-guid</name>
+                    <value>97b77b40-07d8-11f0-8028-444553540001</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>button</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>2</value>
+                </property>
+                <property type="bool">
+                    <name>value</name>
+                    <value>False</value>
+                </property>
+            </macro-action>
+            <macro-action type="key">
+                <property type="int">
+                    <name>scan-code</name>
+                    <value>32</value>
+                </property>
+                <property type="bool">
+                    <name>is-extended</name>
+                    <value>False</value>
+                </property>
+                <property type="bool">
+                    <name>is-pressed</name>
+                    <value>True</value>
+                </property>
+            </macro-action>
+            <macro-action type="key">
+                <property type="int">
+                    <name>scan-code</name>
+                    <value>32</value>
+                </property>
+                <property type="bool">
+                    <name>is-extended</name>
+                    <value>False</value>
+                </property>
+                <property type="bool">
+                    <name>is-pressed</name>
+                    <value>False</value>
+                </property>
+            </macro-action>
+            <macro-action type="mouse-button">
+                <property type="string">
+                    <name>button</name>
+                    <value>Right</value>
+                </property>
+                <property type="bool">
+                    <name>is-pressed</name>
+                    <value>True</value>
+                </property>
+            </macro-action>
+            <macro-action type="mouse-button">
+                <property type="string">
+                    <name>button</name>
+                    <value>Right</value>
+                </property>
+                <property type="bool">
+                    <name>is-pressed</name>
+                    <value>False</value>
+                </property>
+            </macro-action>
+            <macro-action type="mouse-motion">
+                <property type="int">
+                    <name>dx</name>
+                    <value>2</value>
+                </property>
+                <property type="int">
+                    <name>dy</name>
+                    <value>4</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>button</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>1</value>
+                </property>
+                <property type="bool">
+                    <name>value</name>
+                    <value>True</value>
+                </property>
+            </macro-action>
+            <macro-action type="vjoy">
+                <property type="int">
+                    <name>vjoy-id</name>
+                    <value>1</value>
+                </property>
+                <property type="input_type">
+                    <name>input-type</name>
+                    <value>button</value>
+                </property>
+                <property type="int">
+                    <name>input-id</name>
+                    <value>1</value>
+                </property>
+                <property type="bool">
+                    <name>value</name>
+                    <value>False</value>
+                </property>
+            </macro-action>
+            <property type="string">
+                <name>action-label</name>
+                <value>Macro</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>press</value>
+            </property>
+        </action>
+        <action id="66cfeb76-bc9d-4754-925c-3563654db158" type="root">
+            <actions>
+                <action-id>8759f48d-8879-488a-9895-07503bf0dc0c</action-id>
+            </actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Root</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+    </library>
+    <modes>
+        <mode>Default</mode>
+    </modes>
+    <scripts/>
+</profile>


### PR DESCRIPTION
Adds core library and UI

Per our discussion in #447  this is currently quite simple. We don't check for cases where the swap will create invalid bindings, like:

> Obviously there is the issue of not knowing how many inputs exist on a disconnected device

Let me know if you'd like to see more features or checks.

UI with source device disconnected:
<img width="1393" height="783" alt="SwapDevicesDisconnected" src="https://github.com/user-attachments/assets/d30cffd5-6842-4e86-9ae9-ce38cf52a4dc" />

and when connected:

<img width="1401" height="862" alt="SwapDevicesConnected" src="https://github.com/user-attachments/assets/1bb4080b-a943-4849-b085-6065cedd9a23" />

I'll add more unit test coverage in the next few days.