### PR TITLE
Add @override decorator to action plugins

### DIFF
--- a/action_plugins/chain/__init__.py
+++ b/action_plugins/chain/__init__.py
@@ -24,6 +24,7 @@ from xml.etree import ElementTree
 from PySide6 import QtCore
 from PySide6.QtCore import Property, Signal, Slot
 
+from typing import override
 from gremlin import event_handler, util
 from gremlin.base_classes import AbstractActionData, AbstractFunctor, \
     Value
@@ -47,6 +48,7 @@ class ChainFunctor(AbstractFunctor):
         self.current_index = 0
         self.last_execution = 0.0
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -153,6 +155,7 @@ class ChainData(AbstractActionData):
         self.chain_sequences = [[],]
         self.timeout = 0.0
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.timeout = util.read_property(node, "timeout", PropertyType.Float)
@@ -166,6 +169,7 @@ class ChainData(AbstractActionData):
         for idx in sorted(chain_dict.keys()):
             self.chain_sequences.append(chain_dict[idx])
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(ChainData.tag, self._id)
         for i, chain in enumerate(self.chain_sequences):
@@ -177,18 +181,22 @@ class ChainData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return [str(i) for i in range(len(self.chain_sequences))]
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         index = int(selector)
         if index < 0 or index >= len(self.chain_sequences):
             raise GremlinError(f"Index {index} invalid as chain container")
         return self.chain_sequences[index]
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/change_mode/__init__.py
+++ b/action_plugins/change_mode/__init__.py
@@ -22,7 +22,7 @@ import enum
 import logging
 import threading
 import time
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -77,6 +77,7 @@ class ChangeModeFunctor(AbstractFunctor):
             self._mode_sequence = \
                 mode_manager.ModeSequence(self.data._target_modes)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -268,6 +269,7 @@ class ChangeModeData(AbstractActionData):
 
         self._target_modes = value
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self._change_type = ChangeType.lookup(util.read_property(
@@ -279,6 +281,7 @@ class ChangeModeData(AbstractActionData):
                 entry, "name", PropertyType.String
             ))
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(ChangeModeData.tag, self._id)
         node.append(util.create_property_node(
@@ -290,15 +293,19 @@ class ChangeModeData(AbstractActionData):
             ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise error.GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
             self,
             old_behavior: InputType,

--- a/action_plugins/condition/__init__.py
+++ b/action_plugins/condition/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -50,6 +50,7 @@ class ConditionFunctor(AbstractFunctor):
     def __init__(self, action: ConditionModel) -> None:
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: event_handler.Event,
@@ -243,6 +244,7 @@ class ConditionData(AbstractActionData):
         self.false_actions = []
         self.conditions = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         # Parse IF action ids
@@ -282,6 +284,7 @@ class ConditionData(AbstractActionData):
                 cond_obj.from_xml(entry)
                 self.conditions.append(cond_obj)
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(ConditionData.tag, self._id)
         node.append(util.create_property_node(
@@ -300,12 +303,15 @@ class ConditionData(AbstractActionData):
 
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["true", "false"]
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         match selector:
             case "true":
@@ -317,6 +323,7 @@ class ConditionData(AbstractActionData):
                     f"{self.name}: has no container with name {selector}"
                 )
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/description/__init__.py
+++ b/action_plugins/description/__init__.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -42,6 +42,7 @@ class DescriptionFunctor(AbstractFunctor):
     def __init__(self, action: DescriptionData) -> None:
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: event_handler.Event,
@@ -124,12 +125,14 @@ class DescriptionData(AbstractActionData):
         # Model variables
         self.description = ""
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.description = util.read_property(
             node, "description", PropertyType.String
         )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(DescriptionData.tag, self._id)
         node.append(util.create_property_node(
@@ -137,15 +140,19 @@ class DescriptionData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/double_tap/__init__.py
+++ b/action_plugins/double_tap/__init__.py
@@ -22,7 +22,7 @@ import copy
 import logging
 import threading
 import time
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -51,6 +51,7 @@ class DoubleTapFunctor(AbstractFunctor):
         self.event_press = None
         self.fsm = self._create_fsm()
 
+    @override
     def __call__(
             self,
             event: event_handler.Event,
@@ -233,6 +234,7 @@ class DoubleTapData(AbstractActionData):
         self.threshold = Configuration().value("action", "double-tap", "duration")
         self.activate_on = "exclusive"
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         short_ids = util.read_action_ids(node.find("single-actions"))
@@ -250,6 +252,7 @@ class DoubleTapData(AbstractActionData):
                 f"Invalid activat-on value present: {self.activate_on}"
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         """Returns an XML node representing this container's data.
 
@@ -271,12 +274,15 @@ class DoubleTapData(AbstractActionData):
 
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["single", "double"]
 
+    @override
     def _get_container(
             self,
             selector: Optional[str] = None
@@ -286,6 +292,7 @@ class DoubleTapData(AbstractActionData):
         elif selector == "double":
             return self.double_actions
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/dual_axis_deadzone/__init__.py
+++ b/action_plugins/dual_axis_deadzone/__init__.py
@@ -22,7 +22,7 @@ import collections
 import copy
 import logging
 import math
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore, QtGui, QtQml
@@ -56,6 +56,7 @@ class DualAxisDeadzoneFunctor(AbstractFunctor):
 
         self.joy = Joystick()
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -280,6 +281,7 @@ class DualAxisDeadzoneData(AbstractActionData):
         self.output1_actions = []
         self.output2_actions = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
 
@@ -316,6 +318,7 @@ class DualAxisDeadzoneData(AbstractActionData):
         self.output2_actions = \
             [library.get_action(aid) for aid in output2_actions]
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(DualAxisDeadzoneData.tag, self._id)
 
@@ -341,20 +344,24 @@ class DualAxisDeadzoneData(AbstractActionData):
 
         return node
 
+    @override
     def is_valid(self) -> bool:
         axis_valid = self.axis1.isValid and self.axis2.isValid
         deadzone_valid = abs(self.outer_deadzone - self.inner_deadzone) >= 0.01
         return axis_valid and deadzone_valid
 
+    @override
     def _valid_selectors(self) -> list[str]:
         return ["first", "second"]
 
+    @override
     def _get_container(self, selector: str) -> list[AbstractActionData]:
         if selector == "first":
             return self.output1_actions
         elif selector == "second":
             return self.output2_actions
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/hat_buttons/__init__.py
+++ b/action_plugins/hat_buttons/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import copy
 import time
 from collections.abc import Callable
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -85,6 +85,7 @@ class DirectionalButton:
         }
         return fsm.FiniteStateMachine("up", states, actions, transitions)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -239,6 +240,7 @@ class HatButtonsData(AbstractActionData):
         for name in HatButtonsData. name_list[self.button_count]:
             self.direction[name] = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.button_count = util.read_property(
@@ -253,6 +255,7 @@ class HatButtonsData(AbstractActionData):
             action_ids = util.read_action_ids(elem)
             self.direction[key] = [library.get_action(aid) for aid in action_ids]
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(HatButtonsData.tag, self._id)
         node.append(util.create_property_node(
@@ -264,17 +267,21 @@ class HatButtonsData(AbstractActionData):
             ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return list(self.direction.keys())
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         if selector not in self.direction:
             raise GremlinError(f"Key {selector} invalid as hat direction")
         return self.direction[selector]
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/load_profile/__init__.py
+++ b/action_plugins/load_profile/__init__.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -48,6 +48,7 @@ class LoadProfileFunctor(AbstractFunctor):
     def __init__(self, action: LoadProfileData):
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -138,6 +139,7 @@ class LoadProfileData(AbstractActionData):
         # Model variables
         self.profile_filename = ""
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.profile_filename = util.read_property(
@@ -147,6 +149,7 @@ class LoadProfileData(AbstractActionData):
         if not self.is_valid():
             raise GremlinError(f"{self.profile_filename} does not exists or is not accessible.")
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(LoadProfileData.tag, self._id)
         node.append(util.create_property_node(
@@ -154,15 +157,19 @@ class LoadProfileData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return file_exists_and_is_accessible(self.profile_filename)
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/macro/__init__.py
+++ b/action_plugins/macro/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import enum
 from itertools import count
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from unittest import case
 from xml.etree import ElementTree
 
@@ -630,6 +630,7 @@ class MacroFunctor(AbstractFunctor):
                     self.data.repeat_data.delay
                 )
 
+    @override
     def __call__(
             self,
             event: event_handler.Event,
@@ -835,6 +836,7 @@ class MacroData(AbstractActionData):
         self.repeat_mode = MacroRepeatModes.Single
         self.repeat_data = MacroRepeatData()
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         type_lookup = {
             "joystick": macro.JoystickAction.create,
@@ -872,6 +874,7 @@ class MacroData(AbstractActionData):
                     f"id {self._id}"
                 )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MacroData.tag, self._id)
         util.append_property_nodes(
@@ -887,15 +890,19 @@ class MacroData(AbstractActionData):
             node.append(entry.to_xml())
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/map_to_keyboard/__init__.py
+++ b/action_plugins/map_to_keyboard/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import enum
 import math
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -49,6 +49,7 @@ class MapToKeyboardFunctor(AbstractFunctor):
         for key in reversed(self.data.keys):
             self.release.release(key)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -142,6 +143,7 @@ class MapToKeyboardData(AbstractActionData):
 
         self.keys = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         for key_node in node.findall("input"):
@@ -151,6 +153,7 @@ class MapToKeyboardData(AbstractActionData):
             )
             self.keys.append(key)
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MapToKeyboardData.tag, self._id)
         for key in self.keys:
@@ -163,15 +166,19 @@ class MapToKeyboardData(AbstractActionData):
             ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return len(self.keys) > 0
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/map_to_logical_device/__init__.py
+++ b/action_plugins/map_to_logical_device/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, override
 import uuid
 from xml.etree import ElementTree
 
@@ -49,6 +49,7 @@ class MapToLogicalDeviceFunctor(AbstractFunctor):
         self._logical = LogicalDevice()
         self._event_listener = EventListener()
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -246,6 +247,7 @@ class MapToLogicalDeviceData(AbstractActionData):
         self.axis_scaling = 1.0
         self.button_inverted = False
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.logical_input_id = util.read_property(
@@ -266,6 +268,7 @@ class MapToLogicalDeviceData(AbstractActionData):
                 node, "button-inverted", PropertyType.Bool
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MapToLogicalDeviceData.tag, self._id)
         node.append(util.create_property_node(
@@ -287,15 +290,19 @@ class MapToLogicalDeviceData(AbstractActionData):
             ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/map_to_mouse/__init__.py
+++ b/action_plugins/map_to_mouse/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import enum
 import math
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -61,6 +61,7 @@ class MapToMouseFunctor(AbstractFunctor):
 
         self.mouse_controller = sendinput.MouseController()
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -314,6 +315,7 @@ class MapToMouseData(AbstractActionData):
         self.max_speed = 15
         self.time_to_max_speed = 1.0
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.mode = MapToMouseMode.lookup(util.read_property(
@@ -331,6 +333,7 @@ class MapToMouseData(AbstractActionData):
                 node, "time-to-max-speed", PropertyType.Float
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MapToMouseData.tag, self._id)
         entries = [
@@ -351,15 +354,19 @@ class MapToMouseData(AbstractActionData):
         util.append_property_nodes(node, entries)
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/map_to_vjoy/__init__.py
+++ b/action_plugins/map_to_vjoy/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -58,6 +58,7 @@ class MapToVjoyFunctor(AbstractFunctor):
         self.axis_delta_value = 0.0
         self.axis_value = 0.0
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -309,9 +310,11 @@ class MapToVjoyData(AbstractActionData):
         self.button_inverted = False
 
     @classmethod
+    @override
     def can_create(cls) -> bool:
         return len(device_initialization.vjoy_devices()) > 0
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.vjoy_device_id = util.read_property(
@@ -335,6 +338,7 @@ class MapToVjoyData(AbstractActionData):
                 node, "button-inverted", PropertyType.Bool
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MapToVjoyData.tag, self._id)
         node.append(util.create_property_node(
@@ -359,15 +363,19 @@ class MapToVjoyData(AbstractActionData):
             ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise error.GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/merge_axis/__init__.py
+++ b/action_plugins/merge_axis/__init__.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 import uuid
 from xml.etree import ElementTree
 
@@ -96,6 +96,7 @@ class MergeAxisFunctor(AbstractFunctor):
     def __init__(self, action: MergeAxisData):
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -353,6 +354,7 @@ class MergeAxisData(AbstractActionData):
 
         self.children = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.label = util.read_property(node, "label", PropertyType.String)
@@ -376,6 +378,7 @@ class MergeAxisData(AbstractActionData):
         child_ids = util.read_action_ids(node.find("actions"))
         self.children = [library.get_action(aid) for aid in child_ids]
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(MergeAxisData.tag, self._id)
         entries = [
@@ -397,9 +400,11 @@ class MergeAxisData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def swap_uuid(self, old_uuid: uuid.UUID, new_uuid: uuid.UUID) -> bool:
         performed_swap = False
         if self.axis_in1.device_guid == old_uuid:
@@ -411,6 +416,7 @@ class MergeAxisData(AbstractActionData):
         return performed_swap
 
     @classmethod
+    @override
     def _do_create(
             cls,
             mode: DataCreationMode,
@@ -425,13 +431,16 @@ class MergeAxisData(AbstractActionData):
             else:
                 return all_actions[0]
 
+    @override
     def _valid_selectors(self) -> list[str]:
         return ["children"]
 
+    @override
     def _get_container(self, selector: str) -> list[AbstractActionData]:
         if selector == "children":
             return self.children
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/pause_resume/__init__.py
+++ b/action_plugins/pause_resume/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -60,6 +60,7 @@ class PauseResumeFunctor(AbstractFunctor):
     def __init__(self, action: PauseResumeData):
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -146,12 +147,14 @@ class PauseResumeData(AbstractActionData):
         # Model variables
         self.operation = PauseResumeType.Pause
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         self.operation = PauseResumeType.lookup(util.read_property(
             node, "operation", PropertyType.String
         ))
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(PauseResumeData.tag, self._id)
         node.append(util.create_property_node(
@@ -159,15 +162,19 @@ class PauseResumeData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/play_sound/__init__.py
+++ b/action_plugins/play_sound/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -48,6 +48,7 @@ class PlaySoundFunctor(AbstractFunctor):
     def __init__(self, action: PlaySoundData):
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -147,6 +148,7 @@ class PlaySoundData(AbstractActionData):
         self.sound_filename: str = ""
         self.sound_volume: int = 50
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
 
@@ -162,6 +164,7 @@ class PlaySoundData(AbstractActionData):
                 f"{self.sound_filename} does not exists or is not accessible."
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(PlaySoundData.tag, self._id)
         util.append_property_nodes(
@@ -173,15 +176,19 @@ class PlaySoundData(AbstractActionData):
         )
         return node
 
+    @override
     def is_valid(self) -> bool:
         return file_exists_and_is_accessible(self.sound_filename)
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/reference/__init__.py
+++ b/action_plugins/reference/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -155,6 +155,7 @@ class ReferenceData(AbstractActionData):
     ):
         super().__init__(behavior_type)
 
+    @override
     def _from_xml(
             self,
             node: ElementTree.Element,
@@ -162,18 +163,23 @@ class ReferenceData(AbstractActionData):
     ) -> None:
         pass
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         return ElementTree.Element()
 
+    @override
     def is_valid(self) -> bool:
         return False
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/response_curve/__init__.py
+++ b/action_plugins/response_curve/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore, QtGui, QtQml
@@ -84,6 +84,7 @@ class ResponseCurveFunctor(AbstractFunctor):
     def __init__(self, action: ResponseCurveData):
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -448,6 +449,7 @@ class ResponseCurveData(AbstractActionData):
         self.deadzone = [-1.0, 0.0, 0.0, 1.0]
         self.curve = spline.PiecewiseLinear()
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         lookup = {
             "PiecewiseLinear": spline.PiecewiseLinear,
@@ -475,6 +477,7 @@ class ResponseCurveData(AbstractActionData):
             node, "curve-type", PropertyType.String
         )]([[p.x, p.y] for p in points])
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         lookup = {
             spline.PiecewiseLinear: "PiecewiseLinear",
@@ -516,15 +519,19 @@ class ResponseCurveData(AbstractActionData):
 
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return []
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         raise GremlinError(f"{self.name}: has no containers")
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/root/__init__.py
+++ b/action_plugins/root/__init__.py
@@ -22,7 +22,7 @@ import copy
 import logging
 import threading
 import time
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -48,6 +48,7 @@ class RootFunctor(AbstractFunctor):
     def __init__(self, action: RootData) -> None:
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -115,11 +116,13 @@ class RootData(AbstractActionData):
 
         self.children = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         child_ids = util.read_action_ids(node.find("actions"))
         self.children = [library.get_action(aid) for aid in child_ids]
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(RootData.tag, self._id)
         node.append(util.create_action_ids(
@@ -128,16 +131,20 @@ class RootData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["children"]
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         if selector == "children":
             return self.children
 
+    @override
     def _handle_behavior_change(
             self,
             old_behavior: InputType,

--- a/action_plugins/smart_toggle/__init__.py
+++ b/action_plugins/smart_toggle/__init__.py
@@ -22,7 +22,7 @@ import copy
 import logging
 import threading
 import time
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -80,6 +80,7 @@ class SmartToggleFunctor(AbstractFunctor):
         self.timer = threading.Timer(self.data.delay, self._timeout)
         self.timer.start()
 
+    @override
     def __call__(
             self,
             event: event_handler.Event,
@@ -170,12 +171,14 @@ class SmartToggleData(AbstractActionData):
         self.delay = Configuration().value("action", "smart-toggle", "duration")
         self.children = []
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         child_ids = util.read_action_ids(node.find("actions"))
         self.children = [library.get_action(aid) for aid in child_ids]
         self.delay = util.read_property(node, "delay", PropertyType.Float)
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(SmartToggleData.tag, self._id)
         node.append(util.create_action_ids(
@@ -187,16 +190,20 @@ class SmartToggleData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["children"]
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         if selector == "children":
             return self.children
 
+    @override
     def _handle_behavior_change(
             self,
             old_behavior: InputType,

--- a/action_plugins/split_axis/__init__.py
+++ b/action_plugins/split_axis/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -40,6 +40,7 @@ class SplitAxisFunctor(AbstractFunctor):
     def __init__(self, action: SplitAxisData) -> None:
         super().__init__(action)
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -121,6 +122,7 @@ class SplitAxisData(AbstractActionData):
         self.upper_actions: List[AbstractActionData] = []
         self.split_value: float = 0.0
 
+    @override
     def _from_xml(
             self,
             node: ElementTree.Element,
@@ -135,6 +137,7 @@ class SplitAxisData(AbstractActionData):
             node, "split-value", PropertyType.Float
         )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(self.tag, self._id)
         node.append(util.create_property_node(
@@ -148,12 +151,15 @@ class SplitAxisData(AbstractActionData):
         ))
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["lower", "upper"]
 
+    @override
     def _get_container(self, selector: str) -> List[AbstractActionData]:
         match selector:
             case "lower":
@@ -165,6 +171,7 @@ class SplitAxisData(AbstractActionData):
                     f"{self.name}: has no container with name {selector}"
                 )
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,

--- a/action_plugins/tempo/__init__.py
+++ b/action_plugins/tempo/__init__.py
@@ -22,7 +22,7 @@ import copy
 import logging
 import threading
 import time
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING, override
 from xml.etree import ElementTree
 
 from PySide6 import QtCore
@@ -53,6 +53,7 @@ class TempoFunctor(AbstractFunctor):
         self.event_press = None
         self.fsm = self._create_fsm()
 
+    @override
     def __call__(
             self,
             event: Event,
@@ -221,6 +222,7 @@ class TempoData(AbstractActionData):
         self.threshold = Configuration().value("action", "tempo", "duration")
         self.activate_on = "release"
 
+    @override
     def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
         self._id = util.read_action_id(node)
         short_ids = util.read_action_ids(node.find("short-actions"))
@@ -238,6 +240,7 @@ class TempoData(AbstractActionData):
                 f"Invalid activat-on value present: {self.activate_on}"
             )
 
+    @override
     def _to_xml(self) -> ElementTree.Element:
         node = util.create_action_node(TempoData.tag, self._id)
         node.append(util.create_action_ids(
@@ -255,12 +258,15 @@ class TempoData(AbstractActionData):
 
         return node
 
+    @override
     def is_valid(self) -> bool:
         return True
 
+    @override
     def _valid_selectors(self) -> List[str]:
         return ["long", "short"]
 
+    @override
     def _get_container(
             self,
             selector: Optional[str] = None
@@ -270,6 +276,7 @@ class TempoData(AbstractActionData):
         elif selector == "long":
             return self.long_actions
 
+    @override
     def _handle_behavior_change(
         self,
         old_behavior: InputType,


### PR DESCRIPTION
[Commit made by Jules bot. I eyeballed the changes and they look good. Pyright in my IDE has no issues with the type hints either]

Applied the @override decorator to methods in action plugins that override base class methods, specifically for subclasses of AbstractActionData and AbstractFunctor.

- Added `from typing import override`
- Decorated methods like `__call__`, `_from_xml`, `_to_xml`, `is_valid`, `_valid_selectors`, `_get_container`, `_handle_behavior_change` and others where appropriate.