### PR TITLE
Add pyright configuration to the TOML file

### DIFF
--- a/gremlin/base_classes.py
+++ b/gremlin/base_classes.py
@@ -17,11 +17,11 @@
 
 from __future__ import annotations
 
-import typing
 from abc import abstractmethod, ABC
 import copy
 import time
-from typing import Any, List, Tuple, Optional
+import typing
+from typing import Any, List, Self, Tuple, Type, Optional
 import uuid
 from xml.etree import ElementTree
 
@@ -84,11 +84,11 @@ class AbstractActionData(ABC):
     # Fields expected to be present in every action plugin. These define
     # information required by the plugin manager as well as UI and behavior
     # logic.
-    version : int = -1
-    name : str = ""
-    tag : str = ""
-    icon : str = ""
-    functor = None
+    version : int
+    name : str
+    tag : str
+    icon : str
+    functor: Type[AbstractFunctor]
     model = None
     properties: Tuple[ActionProperty, ...] = ()
     input_types: Tuple[InputType, ...] = ()
@@ -216,13 +216,13 @@ class AbstractActionData(ABC):
         )
         self._from_xml(node, library)
 
-    def to_xml(self) -> ElementTree.Element:
+    def to_xml(self) -> Optional[ElementTree.Element]:
         """Returns an XML node representing the instance's contents.
 
         Calls the implementation specific serialization routine.
 
         Returns:
-            XML node containing the instance's contents
+            XML node containing the instance's contents, or None if invalid
         """
         if not self.is_valid():
             print(f"This node is invalid {self.id}")
@@ -336,7 +336,7 @@ class AbstractActionData(ABC):
         else:
             if not (0 <= anchor <= len(container)):
                 raise GremlinError(
-                    f"{self.name}: specified anchor index '{anchor.id}' is " +
+                    f"{self.name}: specified anchor index '{anchor}' is " +
                     f"not present in container '{selector}'"
                 )
             if mode == DataInsertionMode.Append:
@@ -393,7 +393,7 @@ class AbstractActionData(ABC):
             cls,
             mode: DataCreationMode,
             behavior_type: InputType
-    ) -> AbstractActionData:
+    ) -> Self:
         """Allows customization of instance creation in derived classes.
 
         Args:
@@ -403,7 +403,7 @@ class AbstractActionData(ABC):
         Returns:
             Newly created instance
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def _valid_selectors(self) -> List[str]:

--- a/gremlin/base_classes.py
+++ b/gremlin/base_classes.py
@@ -20,18 +20,17 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 import copy
 import time
-import typing
-from typing import Any, List, Self, Tuple, Type, Optional
+from typing import Any, List, Self, Tuple, Type, TYPE_CHECKING, Optional
 import uuid
 from xml.etree import ElementTree
 
 from gremlin import util, event_handler
-from gremlin.error import GremlinError
+from gremlin.error import GremlinError, MissingImplementationError
 from gremlin.profile import Library
 from gremlin.types import ActionActivationMode, ActionProperty, InputType, \
     PropertyType, DataInsertionMode, DataCreationMode
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from gremlin.event_handler import Event
     from gremlin.ui.action_model import ActionModel
 
@@ -403,7 +402,8 @@ class AbstractActionData(ABC):
         Returns:
             Newly created instance
         """
-        raise NotImplementedError
+        raise MissingImplementationError(
+            f"{cls._do_create.__name__} not implemented by derived class {cls.__name__}")
 
     @abstractmethod
     def _valid_selectors(self) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ lint.select = ["ANN"]
 lint.ignore = ["ANN401"]
 
 [tool.pyright]
-include = ["action_plugins", "gremlin", "joystick_gremlin.py"]
+include = ["action_plugins", "dill", "gremlin", "joystick_gremlin.py", "vjoy"]
 exclude = ["**/__pycache__", "**/.git", "**/.venv", "**/venv"]
 reportMissingImports = true
 reportMissingTypeStubs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,12 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 lint.select = ["ANN"]
 lint.ignore = ["ANN401"]
+
+[tool.pyright]
+include = ["action_plugins", "gremlin", "joystick_gremlin.py"]
+exclude = ["**/__pycache__", "**/.git", "**/.venv", "**/venv"]
+reportMissingImports = true
+reportMissingTypeStubs = false
+pythonVersion = "3.12"
+pythonPlatform = "Windows"
+typeCheckingMode = "basic"


### PR DESCRIPTION
If you have Pyright set up in the IDE (seems to be default in Visual Studio Code), then this should show type warnings in the `Problems` tab. This way we can fix forward issues it identifies.

I took a stab at fixing one of the files. The current Pyright configuration is a bit relaxed; we can make it more aggressive if you like (the `Problems` tab might fill up a bit more :)