### PR TITLE
Fix bug where periodics from only one script were running.

### DIFF
--- a/gremlin/code_runner.py
+++ b/gremlin/code_runner.py
@@ -454,6 +454,7 @@ class CodeRunner:
         # Retrieve the list of current paths searched by Python
         system_paths = [os.path.normcase(os.path.abspath(p)) for p in sys.path]
 
+        user_script.periodic_registry.clear()
         # Populate custom module variable registry <-- nope
         # Update system path for the user scripts
         for script in self._profile.scripts.scripts:

--- a/gremlin/user_script.py
+++ b/gremlin/user_script.py
@@ -531,10 +531,14 @@ class Script:
         return node
 
     def reload(self):
+        """Reloads this script.
+
+        Calling reload will currently register duplicate callbacks in the
+        periodic registry. The workaround is to clear all periodic callbacks
+        and then reload all scripts.
+        """
         Script.variable_registry.register_script(self)
         self.module._script_id = self.id
-        # Clear periodic registry to avoid duplicate entries.
-        periodic_registry.clear()
         self.spec.loader.exec_module(self.module)
 
     def _retrieve_variable_definitions(self):


### PR DESCRIPTION
I attempted a fix in #640 but that broke this other aspect of periodics

Ideally, a script reload would also clean up its own periodics, but that's a larger refactor - perhaps we'd need a `ScriptPeriodicRegistry`, analogous to `ScriptVariableRegistry`.

Tested by running a profile with two scripts that both have periodics - previously, periodics from only one script would run.