### PR TITLE
Fix e2e integration tests now that loading a profile deactivates gremlin and invalidates vjoy devices

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -53,7 +53,7 @@ def vjoy_di_device(
 
 
 @pytest.fixture(scope="module")
-def vjoy_control_device_id(vjoy_ids_or_skip: list[int]) -> vjoy.VJoy:
+def vjoy_control_device_id(vjoy_ids_or_skip: list[int]) -> int:
     """Returns the vJoy control device to be used for this test."""
     assert vjoy_ids_or_skip
     for vjoy_id in vjoy_ids_or_skip:
@@ -66,7 +66,7 @@ def vjoy_control_device_id(vjoy_ids_or_skip: list[int]) -> vjoy.VJoy:
 def edited_profile(
     profile_from_file: gremlin.profile.Profile,
     vjoy_di_device: dill.DeviceSummary,
-    vjoy_control_device: vjoy.VJoy,
+    vjoy_control_device_id: int,
 ) -> gremlin.profile.Profile:
     """Replaces input/output devices in the profile."""
     # Replace the (only) input device.
@@ -78,7 +78,7 @@ def edited_profile(
 
     # Replace the output device(s) with the single vJoy control device.
     for action in profile_from_file.library.actions_by_type(map_to_vjoy.MapToVjoyData):
-        action.vjoy_device_id = vjoy_control_device.vjoy_id
+        action.vjoy_device_id = vjoy_control_device_id
 
     return profile_from_file
 

--- a/test/integration/test_e2e_user_script.py
+++ b/test/integration/test_e2e_user_script.py
@@ -23,7 +23,6 @@ def profile_name() -> str:
 def edited_profile(
     profile_from_file: profile.Profile,
     vjoy_di_device: dill.DeviceSummary,
-    vjoy_control_device,
 ) -> profile.Profile:
     """Replaces the input device loaded from file with the vJoy device."""
     script = profile_from_file.scripts.scripts[0]


### PR DESCRIPTION
[This commit](https://github.com/WhiteMagic/JoystickGremlin/commit/75f8212e60af6eb8fbe82313814fdb32fa9fc1f3#diff-391e5281c5486339e8fe5831cb86e525b79cf6a68e04f8c5c789a0013c7538dd) broke the tests

The fix is pretty simple, the tests were incorrectly instantiating vJoy devices early to populate the profile when the just needed the vJoy device IDs. Verified by running locally.