### PR TITLE
In SelectionVariable, handle attempts to set invalid incoming gracefully

### DIFF
--- a/gremlin/user_script.py
+++ b/gremlin/user_script.py
@@ -1004,9 +1004,22 @@ class SelectionVariable(AbstractVariable):
     ) -> None:
         super().__init__(name, description, is_optional)
 
+        if default_index >= len(option_list):
+            raise ValueError(
+                f"Default index {default_index} is out of range for option list "
+                f"of length {len(option_list)} for selection variable '{name}'"
+            )
         self._option_list = option_list
-        self._current_index = default_index
+        self._set_current_index(default_index)
         self._initialize_from_registry()
+    
+    def _set_current_index(self, index: int) -> None:
+        if index < len(self._option_list):
+            self._current_index = index
+        else:
+            logging.getLogger("user_script").error(
+                f"Ignoring invalid index {index} for selection variable '{self.name}'"
+            )
 
     @property
     def options(self) -> list[str]:
@@ -1024,9 +1037,9 @@ class SelectionVariable(AbstractVariable):
         return True
 
     def _from_xml(self, node: ElementTree.Element) -> None:
-        self._current_index = util.read_property(
+        self._set_current_index(util.read_property(
             node, "index", PropertyType.Int
-        )
+        ))
 
     def _to_xml(self, node: ElementTree.Element) -> None:
         node.append(util.create_property_node(
@@ -1034,7 +1047,7 @@ class SelectionVariable(AbstractVariable):
         ))
 
     def _assign_value_from(self, other: SelectionVariable) -> None:
-        self._current_index = other._current_index
+        self._set_current_index(other._current_index)
 
 
 class StringVariable(AbstractVariable):

--- a/gremlin/user_script.py
+++ b/gremlin/user_script.py
@@ -1004,8 +1004,8 @@ class SelectionVariable(AbstractVariable):
     ) -> None:
         super().__init__(name, description, is_optional)
 
-        if default_index >= len(option_list):
-            raise ValueError(
+        if not (0 <= default_index < len(option_list)):
+            raise error.PluginError(
                 f"Default index {default_index} is out of range for option list "
                 f"of length {len(option_list)} for selection variable '{name}'"
             )
@@ -1014,10 +1014,10 @@ class SelectionVariable(AbstractVariable):
         self._initialize_from_registry()
     
     def _set_current_index(self, index: int) -> None:
-        if index < len(self._option_list):
+        if 0 <= index < len(self._option_list):
             self._current_index = index
         else:
-            logging.getLogger("user_script").error(
+            logging.getLogger("user_script").warning(
                 f"Ignoring invalid index {index} for selection variable '{self.name}'"
             )
 

--- a/test/unit/test_user_script.py
+++ b/test/unit/test_user_script.py
@@ -198,6 +198,16 @@ class TestScript:
         var_from_xml.from_xml(xml)
         assert var_from_xml.value == value
 
+    def test_selection_variable_with_invalid_default_raises(self):
+        with pytest.raises(ValueError):
+            user_script.SelectionVariable(
+                "Invalid Default Var",
+                "Selection variable with invalid default index",
+                True,
+                ["option1", "option2"],
+                default_index=5,
+            )
+
     def test_selection_variable(self, script_for_test: user_script.Script, subtests):
         """Test selection variable properties."""
         var = script_for_test.get_variable("A selection variable")
@@ -215,6 +225,19 @@ class TestScript:
             var.value = "selection2"
             assert var.value == "selection2"
             assert var.is_valid()
+
+        with subtests.test("handles reduced options"):
+            var.value = "selection3"
+            var_xml = var.to_xml()
+            assert var_xml is not None
+            # Make the selection in XML too large.
+            for child in var_xml:
+                if child.tag == "property" and child.get("name") == "index":
+                    child.text = "4"
+            var.from_xml(var_xml)
+            # Should still be valid with existing value
+            assert var.is_valid()
+            assert var.value == "selection3"  # Previous valid value.
 
     @pytest.mark.parametrize("value", ["selection1", "selection2", "selection3"])
     def test_selection_variable_xml_transforms(

--- a/test/unit/test_user_script.py
+++ b/test/unit/test_user_script.py
@@ -6,7 +6,7 @@ import pathlib
 import pytest
 import uuid
 
-from gremlin import profile, shared_state, types, user_script
+from gremlin import error, profile, shared_state, types, user_script
 from test.unit.conftest import get_fake_device_guid
 
 
@@ -198,15 +198,25 @@ class TestScript:
         var_from_xml.from_xml(xml)
         assert var_from_xml.value == value
 
-    def test_selection_variable_with_invalid_default_raises(self):
-        with pytest.raises(ValueError):
-            user_script.SelectionVariable(
-                "Invalid Default Var",
-                "Selection variable with invalid default index",
-                True,
-                ["option1", "option2"],
-                default_index=5,
-            )
+    def test_selection_variable_with_invalid_default_raises(self, subtests):
+        with subtests.test("default too large"):
+            with pytest.raises(error.PluginError):
+                user_script.SelectionVariable(
+                    "Var With Default Index Too Large",
+                    "Selection variable with invalid default index",
+                    True,
+                    ["option1", "option2"],
+                    default_index=5,
+                )
+        with subtests.test("negative default index not allowed"):
+            with pytest.raises(error.PluginError):
+                user_script.SelectionVariable(
+                    "Var With Default Index Negative",
+                    "Selection variable with invalid default index",
+                    True,
+                    ["option1", "option2"],
+                    default_index=-1,
+                )
 
     def test_selection_variable(self, script_for_test: user_script.Script, subtests):
         """Test selection variable properties."""


### PR DESCRIPTION
Otherwise, if the profile-saved current index becomes too large for a SelectionVariable (I have a plugin where this is populated by detecting devices), we keep getting exceptions at various points.