### PR TITLE
Fix input viewer for PySide > 6.10

### DIFF
--- a/gremlin/ui/device.py
+++ b/gremlin/ui/device.py
@@ -1205,7 +1205,7 @@ class AbstractDeviceState(QtCore.QAbstractListModel):
         self._device_uuid = None
         self._state = []
 
-    def _event_callback(self, event: event_handler.Event):
+    def _event_callback(self, event: event_handler.Event) -> None:
         if event.device_guid != self._device_uuid:
             return
 
@@ -1215,6 +1215,9 @@ class AbstractDeviceState(QtCore.QAbstractListModel):
         raise GremlinError(
             "AbstractDeviceState._event_handler_impl not implemented"
         )
+
+    def _get_guid(self) -> str:
+        return str(self._device.device_guid) if self._device is not None else ""
 
     def _set_guid(self, guid: str) -> None:
         if self._device is not None and guid == str(self._device.device_guid):
@@ -1251,6 +1254,7 @@ class AbstractDeviceState(QtCore.QAbstractListModel):
 
     guid = Property(
         str,
+        fget=_get_guid,
         fset=_set_guid,
         notify=deviceChanged
     )
@@ -1340,6 +1344,9 @@ class DeviceAxisSeries(QtCore.QObject):
         self._identifier_map = {}
         self._window_size = 20
 
+    def _get_guid(self) -> str:
+        return str(self._device.device_guid) if self._device is not None else ""
+
     def _set_guid(self, guid: str) -> None:
         if self._device is not None and guid == str(self._device.device_guid):
             return
@@ -1415,6 +1422,7 @@ class DeviceAxisSeries(QtCore.QObject):
 
     guid = Property(
         str,
+        fget=_get_guid,
         fset=_set_guid,
         notify=deviceChanged
     )

--- a/qml/AxesStateCurrent.qml
+++ b/qml/AxesStateCurrent.qml
@@ -16,10 +16,7 @@ Item {
     property string deviceGuid
     property string title
 
-    function compute_height(available_width)
-    {
-        return _list.height + _header.height + 10
-    }
+    implicitHeight: _content.implicitHeight
 
     function format_percentage(value)
     {
@@ -33,6 +30,8 @@ Item {
     }
 
     ColumnLayout {
+        id: _content
+
         anchors.left: parent.left
         anchors.right: parent.right
 

--- a/qml/AxesStateSeries.qml
+++ b/qml/AxesStateSeries.qml
@@ -27,10 +27,7 @@ Item {
         "#9467bd",
     ]
 
-    function compute_height(available_width)
-    {
-        return _chart.height + _header.height
-    }
+    implicitHeight: _content.implicitHeight
 
     DeviceAxisSeries {
         id: _axis_series
@@ -64,6 +61,8 @@ Item {
     }
 
     ColumnLayout {
+        id: _content
+
         anchors.left: parent.left
         anchors.right: parent.right
 

--- a/qml/ButtonState.qml
+++ b/qml/ButtonState.qml
@@ -16,6 +16,8 @@ Item {
     property string deviceGuid
     property string title
 
+    implicitHeight: _content.implicitHeight
+
     function computeButtonHeight() {
         let columns =  Math.floor(
             Math.max(_button_grid.width, _button_grid.Layout.minimumWidth) /
@@ -25,12 +27,8 @@ Item {
         return rows * _button_grid.cellHeight
     }
 
-    function compute_height(available_width) {
-        let hat_rows = Math.ceil(_hat_grid.count / 2)
-        return Math.max(
-            computeButtonHeight(),
-            hat_rows * _hat_grid.cellHeight
-         ) + _header.height
+    function computeHatHeight(cellHeight) {
+        return Math.ceil(_hat_grid.count / 2) * cellHeight
     }
 
     DeviceButtonState {
@@ -46,6 +44,8 @@ Item {
     }
 
     ColumnLayout {
+        id: _content
+
         anchors.left: parent.left
         anchors.right: parent.right
 
@@ -110,7 +110,7 @@ Item {
                 Layout.fillWidth: true
                 Layout.minimumWidth: 200
                 Layout.preferredWidth: 200
-                Layout.preferredHeight: _root.implicitHeight
+                Layout.minimumHeight: computeHatHeight(cellHeight)
                 Layout.alignment: Qt.AlignTop
 
                 boundsMovement: Flickable.StopAtBounds

--- a/qml/DialogInputViewer.qml
+++ b/qml/DialogInputViewer.qml
@@ -45,25 +45,19 @@ Window {
         deviceType: "all"
     }
 
-    function recompute_height() {
-        for(let i=0; i<_stateDisplay.children.length; ++i) {
-            let elem = _stateDisplay.children[i]
-            elem.implicitHeight = elem.compute_height(_stateDisplay.width)
-        }
-    }
-
     function create_widget(qml_path, guid, name) {
         let component = Qt.createComponent(Qt.resolvedUrl(qml_path))
-        let widget = component.createObject(
-            _stateDisplay,
-            {
-                deviceGuid: guid,
-                title: name
-            }
-        )
+        if (component.status == Component.Ready) {
+            var widget = component.createObject(
+                _stateDisplay,
+                {
+                    deviceGuid: guid,
+                    title: name,
+                    "Layout.fillWidth": true
+                }
+            );
+        }
 
-        widget.Layout.fillWidth = true
-        recompute_height()
         return widget
     }
 
@@ -76,7 +70,7 @@ Window {
             Layout.alignment: Qt.AlignTop
             Layout.rightMargin: 10
             Layout.minimumWidth: 250
-            Layout.fillWidth: false
+            Layout.maximumWidth: 400
             Layout.fillHeight: true
 
             ColumnLayout {
@@ -91,14 +85,14 @@ Window {
 
         // Dynamic scrollview that contains dynamically generated widgets.
         ScrollView  {
-            id: _dynamic_scroll
+            id: _dynamicScroll
 
             Layout.fillWidth: true
             Layout.fillHeight: true
 
             Component.onCompleted: () => {
-                _dynamic_scroll.contentItem.boundsMovement = Flickable.StopAtBounds
-                _dynamic_scroll.contentItem.boundsBehavior = Flickable.StopAtBounds
+                _dynamicScroll.contentItem.boundsMovement = Flickable.StopAtBounds
+                _dynamicScroll.contentItem.boundsBehavior = Flickable.StopAtBounds
             }
 
             ColumnLayout {
@@ -106,8 +100,6 @@ Window {
 
                 anchors.left: parent.left
                 anchors.right: parent.right
-
-                onWidthChanged: () => { recompute_height() }
             }
         }
     }


### PR DESCRIPTION
When using PySide6 version 6.11 the Input Viewer showed empty content areas. The reason was due to the model not exposing the "get" version for the deviceGuid which apparently was fine in previous version but broke when moving to the new version.

Also reduced some complexity by letting the already used layouts handle the height computations rather than doing that manually.