### PR TITLE
Implement axis delta action

### DIFF
--- a/action_plugins/axis_delta/AxisDeltaAction.qml
+++ b/action_plugins/axis_delta/AxisDeltaAction.qml
@@ -1,0 +1,136 @@
+// -*- coding: utf-8; -*-
+// SPDX-License-Identifier: GPL-3.0-only
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Universal
+import QtQuick.Layouts
+import QtQuick.Window
+
+import Gremlin.ActionPlugins
+import Gremlin.Profile
+import Gremlin.Style
+import "../../qml"
+
+Item {
+    id: _root
+
+    property AxisDeltaModel action
+
+    implicitHeight: _content.height
+
+    ColumnLayout {
+        id: _content
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+
+        // +-------------------------------------------------------------------
+        // | Threshold configuration
+        // +-------------------------------------------------------------------
+        RowLayout {
+            Label {
+                text: "Change threshold"
+            }
+            FloatSpinBox {
+                minValue: 0.0001
+                maxValue: 2.0
+                stepSize: 0.05
+                value: _root.action.changeThreshold
+
+                onValueModified: (newValue) => {
+                    _root.action.changeThreshold = newValue
+                }
+            }
+            LayoutHorizontalSpacer {}
+        }
+
+        // +-------------------------------------------------------------------
+        // | Positive change actions
+        // +-------------------------------------------------------------------
+        RowLayout {
+            Label {
+                text: "Positive change"
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+            }
+
+            ActionSelector {
+                actionNode: _root.action
+                callback: function(x) { _root.action.appendAction(x, "positive"); }
+            }
+        }
+
+        Rectangle {
+            id: _positiveDivider
+            Layout.fillWidth: true
+            height: 2
+            color: Style.lowColor
+        }
+
+        Repeater {
+            model: _root.action.getActions("positive")
+
+            delegate: ActionNode {
+                action: modelData
+                parentAction: _root.action
+                containerName: "positive"
+
+                Layout.fillWidth: true
+            }
+        }
+
+        // +-------------------------------------------------------------------
+        // | Negative change actions
+        // +-------------------------------------------------------------------
+        RowLayout {
+            Label {
+                text: "Negative change"
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+            }
+
+            ActionSelector {
+                actionNode: _root.action
+                callback: function(x) { _root.action.appendAction(x, "negative"); }
+            }
+        }
+
+        Rectangle {
+            id: _negativeDivider
+            Layout.fillWidth: true
+            height: 2
+            color: Style.lowColor
+        }
+
+        Repeater {
+            model: _root.action.getActions("negative")
+
+            delegate: ActionNode {
+                action: modelData
+                parentAction: _root.action
+                containerName: "negative"
+
+                Layout.fillWidth: true
+            }
+        }
+    }
+
+    ActionDragDropArea {
+        target: _positiveDivider
+        dropCallback: function(drop) {
+            modelData.dropAction(drop.text, modelData.sequenceIndex, "positive");
+        }
+    }
+
+    ActionDragDropArea {
+        target: _negativeDivider
+        dropCallback: function(drop) {
+            modelData.dropAction(drop.text, modelData.sequenceIndex, "negative");
+        }
+    }
+}

--- a/action_plugins/axis_delta/AxisDeltaAction.qml
+++ b/action_plugins/axis_delta/AxisDeltaAction.qml
@@ -32,6 +32,7 @@ Item {
             Label {
                 text: "Change threshold"
             }
+
             FloatSpinBox {
                 minValue: 0.0001
                 maxValue: 2.0
@@ -42,6 +43,7 @@ Item {
                     _root.action.changeThreshold = newValue
                 }
             }
+
             LayoutHorizontalSpacer {}
         }
 
@@ -53,9 +55,7 @@ Item {
                 text: "Positive change"
             }
 
-            Rectangle {
-                Layout.fillWidth: true
-            }
+            LayoutHorizontalSpacer {}
 
             ActionSelector {
                 actionNode: _root.action
@@ -63,22 +63,25 @@ Item {
             }
         }
 
-        Rectangle {
+        HorizontalDivider {
             id: _positiveDivider
+
             Layout.fillWidth: true
-            height: 2
-            color: Style.lowColor
+
+            dividerColor: Style.lowColor
+            lineWidth: 2
+            spacing: 2
         }
 
         Repeater {
             model: _root.action.getActions("positive")
 
             delegate: ActionNode {
+                Layout.fillWidth: true
+
                 action: modelData
                 parentAction: _root.action
                 containerName: "positive"
-
-                Layout.fillWidth: true
             }
         }
 
@@ -90,9 +93,7 @@ Item {
                 text: "Negative change"
             }
 
-            Rectangle {
-                Layout.fillWidth: true
-            }
+            LayoutHorizontalSpacer {}
 
             ActionSelector {
                 actionNode: _root.action
@@ -100,22 +101,25 @@ Item {
             }
         }
 
-        Rectangle {
+        HorizontalDivider {
             id: _negativeDivider
+
             Layout.fillWidth: true
-            height: 2
-            color: Style.lowColor
+
+            dividerColor: Style.lowColor
+            lineWidth: 2
+            spacing: 2
         }
 
         Repeater {
             model: _root.action.getActions("negative")
 
             delegate: ActionNode {
+                Layout.fillWidth: true
+
                 action: modelData
                 parentAction: _root.action
                 containerName: "negative"
-
-                Layout.fillWidth: true
             }
         }
     }

--- a/action_plugins/axis_delta/__init__.py
+++ b/action_plugins/axis_delta/__init__.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8; -*-
+
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    List,
+    override,
+)
+from xml.etree import ElementTree
+
+from PySide6 import QtCore
+
+from gremlin import (
+    event_handler,
+    util,
+)
+from gremlin.base_classes import (
+    AbstractActionData,
+    AbstractFunctor,
+    UserFeedback,
+    Value,
+)
+from gremlin.config import Configuration
+from gremlin.error import GremlinError
+from gremlin.plugin_manager import PluginManager
+from gremlin.profile import Library
+from gremlin.types import (
+    ActionProperty,
+    InputType,
+    PropertyType,
+)
+from gremlin.ui.action_model import (
+    ActionModel,
+    SequenceIndex,
+)
+
+if TYPE_CHECKING:
+    from gremlin.ui.profile import InputItemBindingModel
+
+
+class AxisDeltaFunctor(AbstractFunctor):
+    def __init__(self, action: AxisDeltaData) -> None:
+        super().__init__(action)
+        self._last_value: float | None = None
+        self._accumulated: float = 0.0
+
+    @override
+    def __call__(
+        self,
+        event: event_handler.Event,
+        value: Value,
+        properties: list[ActionProperty] = [],
+    ) -> None:
+        if self._last_value is None:
+            self._last_value = event.value
+            return
+
+        if not event.value:
+            return
+
+        delta = event.value - self._last_value
+        self._last_value = event.value
+        self._accumulated += delta
+
+        press_event = event.clone()
+        press_event.is_pressed = True
+
+        if self._accumulated >= self.data.change_threshold:
+            self._pulse_event(
+                self.functors["positive"], press_event, Value(True), properties
+            )
+            self._accumulated = 0.0
+        elif self._accumulated <= -self.data.change_threshold:
+            self._pulse_event(
+                self.functors["negative"], press_event, Value(True), properties
+            )
+            self._accumulated = 0.0
+
+
+class AxisDeltaModel(ActionModel):
+    changed = QtCore.Signal()
+
+    def __init__(
+        self,
+        data: AbstractActionData,
+        binding_model: InputItemBindingModel,
+        action_index: SequenceIndex,
+        parent_index: SequenceIndex,
+        parent: QtCore.QObject,
+    ) -> None:
+        super().__init__(data, binding_model, action_index, parent_index, parent)
+
+    def _qml_path_impl(self) -> str:
+        return (
+            "file:///"
+            + QtCore.QFile("core_plugins:axis_delta/AxisDeltaAction.qml").fileName()
+        )
+
+    def _action_behavior(self) -> str:
+        return "button"
+
+    def _compatible_actions(self) -> List[str]:
+        action_list = PluginManager().type_action_map[InputType.JoystickButton]
+        action_list = [e for e in action_list if e.tag != "root"]
+        return [a.name for a in sorted(action_list, key=lambda x: x.name)]
+
+    def _get_change_threshold(self) -> float:
+        return self._data.change_threshold
+
+    def _set_change_threshold(self, value: float) -> None:
+        if self._data.change_threshold != value:
+            self._data.change_threshold = value
+            self.changed.emit()
+
+    changeThreshold = QtCore.Property(
+        float, fget=_get_change_threshold, fset=_set_change_threshold, notify=changed
+    )
+
+
+class AxisDeltaData(AbstractActionData):
+    version = 1
+    name = "Axis Delta"
+    tag = "axis-delta"
+    icon = "\uf303"
+
+    functor = AxisDeltaFunctor
+    model = AxisDeltaModel
+
+    properties = (ActionProperty.ActivateDisabled,)
+    input_types = (InputType.JoystickAxis,)
+
+    def __init__(self, behavior_type: InputType = InputType.JoystickAxis) -> None:
+        super().__init__(behavior_type)
+        self.change_threshold: float = Configuration().value(
+            "action", "axis-delta", "threshold"
+        )
+        self.actions_positive: List[AbstractActionData] = []
+        self.actions_negative: List[AbstractActionData] = []
+
+    @override
+    def _from_xml(self, node: ElementTree.Element, library: Library) -> None:
+        self._id = util.read_action_id(node)
+        self.change_threshold = util.read_property(
+            node, "threshold", PropertyType.Float
+        )
+        self.actions_positive = [
+            library.get_action(aid)
+            for aid in util.read_action_ids(node.find("positive-actions"))
+        ]
+        self.actions_negative = [
+            library.get_action(aid)
+            for aid in util.read_action_ids(node.find("negative-actions"))
+        ]
+
+    @override
+    def _to_xml(self) -> ElementTree.Element:
+        node = util.create_action_node(self.tag, self._id)
+        node.append(
+            util.create_property_node(
+                "threshold", self.change_threshold, PropertyType.Float
+            )
+        )
+        node.append(
+            util.create_action_ids(
+                "positive-actions", [a.id for a in self.actions_positive]
+            )
+        )
+        node.append(
+            util.create_action_ids(
+                "negative-actions", [a.id for a in self.actions_negative]
+            )
+        )
+        return node
+
+    @override
+    def user_feedback(self) -> list[UserFeedback]:
+        return []
+
+    @override
+    def _valid_selectors(self) -> List[str]:
+        return ["positive", "negative"]
+
+    @override
+    def _get_container(self, selector: str) -> List[AbstractActionData]:
+        match selector:
+            case "positive":
+                return self.actions_positive
+            case "negative":
+                return self.actions_negative
+            case _:
+                raise GremlinError(
+                    f"{self.name}: has no container with name {selector}"
+                )
+
+    @override
+    def _handle_behavior_change(
+        self, old_behavior: InputType, new_behavior: InputType
+    ) -> None:
+        pass
+
+
+create = AxisDeltaData
+
+Configuration().register(
+    "action",
+    "axis-delta",
+    "threshold",
+    PropertyType.Float,
+    0.1,
+    "Default axis delta threshold before triggering.",
+    {"min": 0.0001, "max": 2.0},
+    True,
+)

--- a/test/action_interaction/profiles/axis_delta.xml
+++ b/test/action_interaction/profiles/axis_delta.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" ?>
+<profile version="14">
+    <inputs>
+        <input>
+            <device-id>f0af472f-8e17-493b-a1eb-7333ee8543f2</device-id>
+            <input-type>axis</input-type>
+            <mode>Default</mode>
+            <input-id>1</input-id>
+            <action-configuration>
+                <root-action>ffffffff-0000-4000-8000-000000000001</root-action>
+                <behavior>axis</behavior>
+            </action-configuration>
+        </input>
+    </inputs>
+    <settings>
+        <startup-mode>Default</startup-mode>
+        <macro-default-delay>0.05</macro-default-delay>
+    </settings>
+    <logical-device>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>1</input-id>
+            <label>Input Axis 1</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>2</input-id>
+            <label>Input Axis 2</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>3</input-id>
+            <label>Input Axis 3</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>4</input-id>
+            <label>Input Axis 4</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>11</input-id>
+            <label>Output Axis 1</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>12</input-id>
+            <label>Output Axis 2</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>13</input-id>
+            <label>Output Axis 3</label>
+        </input>
+        <input>
+            <input-type>axis</input-type>
+            <input-id>14</input-id>
+            <label>Output Axis 4</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>1</input-id>
+            <label>Input Button 1</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>2</input-id>
+            <label>Input Button 2</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>3</input-id>
+            <label>Input Button 3</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>4</input-id>
+            <label>Input Button 4</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>11</input-id>
+            <label>Output Button 1</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>12</input-id>
+            <label>Output Button 2</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>13</input-id>
+            <label>Output Button 3</label>
+        </input>
+        <input>
+            <input-type>button</input-type>
+            <input-id>14</input-id>
+            <label>Output Button 4</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>1</input-id>
+            <label>Input Hat 1</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>2</input-id>
+            <label>Input Hat 2</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>3</input-id>
+            <label>Input Hat 3</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>4</input-id>
+            <label>Input Hat 4</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>11</input-id>
+            <label>Output Hat 1</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>12</input-id>
+            <label>Output Hat 2</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>13</input-id>
+            <label>Output Hat 3</label>
+        </input>
+        <input>
+            <input-type>hat</input-type>
+            <input-id>14</input-id>
+            <label>Output Hat 4</label>
+        </input>
+    </logical-device>
+    <library>
+        <!-- map positive trigger → OUT_BUTTON_1 -->
+        <action id="ffffffff-0000-4000-8000-000000000002" type="map-to-logical-device">
+            <property type="int">
+                <name>logical-input-id</name>
+                <value>11</value>
+            </property>
+            <property type="input_type">
+                <name>logical-input-type</name>
+                <value>button</value>
+            </property>
+            <property type="bool">
+                <name>button-inverted</name>
+                <value>False</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value>Map to Logical Device</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>both</value>
+            </property>
+        </action>
+
+        <!-- map negative trigger → OUT_BUTTON_2 -->
+        <action id="ffffffff-0000-4000-8000-000000000003" type="map-to-logical-device">
+            <property type="int">
+                <name>logical-input-id</name>
+                <value>12</value>
+            </property>
+            <property type="input_type">
+                <name>logical-input-type</name>
+                <value>button</value>
+            </property>
+            <property type="bool">
+                <name>button-inverted</name>
+                <value>False</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value>Map to Logical Device</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>both</value>
+            </property>
+        </action>
+
+        <!-- axis-delta action: threshold=0.3 -->
+        <action id="ffffffff-0000-4000-8000-000000000004" type="axis-delta">
+            <property type="float">
+                <name>threshold</name>
+                <value>0.3</value>
+            </property>
+            <positive-actions>
+                <action-id>ffffffff-0000-4000-8000-000000000002</action-id>
+            </positive-actions>
+            <negative-actions>
+                <action-id>ffffffff-0000-4000-8000-000000000003</action-id>
+            </negative-actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Axis Delta</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+
+        <!-- root for IN_AXIS_1 -->
+        <action id="ffffffff-0000-4000-8000-000000000001" type="root">
+            <actions>
+                <action-id>ffffffff-0000-4000-8000-000000000004</action-id>
+            </actions>
+            <property type="string">
+                <name>action-label</name>
+                <value>Root</value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+    </library>
+    <modes>
+        <mode>Default</mode>
+    </modes>
+    <scripts/>
+    <devices/>
+</profile>

--- a/test/action_interaction/test_axis_delta.py
+++ b/test/action_interaction/test_axis_delta.py
@@ -14,7 +14,11 @@ from .conftest import (
     EventSpec,
     JoystickGremlinBot,
 )
-from .input_definitions import *
+from .input_definitions import (
+    IN_AXIS_1,
+    OUT_BUTTON_1,
+    OUT_BUTTON_2,
+)
 
 
 def test_positive_trigger(jgbot: JoystickGremlinBot, profile_dir: Path) -> None:

--- a/test/action_interaction/test_axis_delta.py
+++ b/test/action_interaction/test_axis_delta.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8; -*-
+
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gremlin.types import InputType
+
+from .conftest import (
+    EventSpec,
+    JoystickGremlinBot,
+)
+from .input_definitions import *
+
+
+def test_positive_trigger(jgbot: JoystickGremlinBot, profile_dir: Path) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    # Initialize last_value without accumulating.
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+
+    # Move past the positive threshold (0.3).
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.35)
+
+    assert EventSpec(InputType.JoystickButton, OUT_BUTTON_1, True) == jgbot.next_event()
+    assert (
+        EventSpec(InputType.JoystickButton, OUT_BUTTON_1, False) == jgbot.next_event()
+    )
+
+    # OUT_BUTTON_2 must not have fired.
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()
+
+
+def test_negative_trigger(jgbot: JoystickGremlinBot, profile_dir: Path) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+    jgbot.set_axis_absolute(IN_AXIS_1, -0.35)
+
+    assert EventSpec(InputType.JoystickButton, OUT_BUTTON_2, True) == jgbot.next_event()
+    assert (
+        EventSpec(InputType.JoystickButton, OUT_BUTTON_2, False) == jgbot.next_event()
+    )
+
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()
+
+
+def test_no_trigger_below_threshold(
+    jgbot: JoystickGremlinBot, profile_dir: Path
+) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+
+    # Small movements in both directions — accumulator never reaches ±0.3.
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.1)
+    jgbot.set_axis_absolute(IN_AXIS_1, -0.1)
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.1)
+
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()
+
+
+def test_accumulation_positive(jgbot: JoystickGremlinBot, profile_dir: Path) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+
+    # Three steps of +0.11 each: 0.11 + 0.11 + 0.11 = 0.33 > 0.3.
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.11)
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.22)
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.33)
+
+    assert EventSpec(InputType.JoystickButton, OUT_BUTTON_1, True) == jgbot.next_event()
+    assert (
+        EventSpec(InputType.JoystickButton, OUT_BUTTON_1, False) == jgbot.next_event()
+    )
+
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()
+
+
+def test_accumulation_negative(jgbot: JoystickGremlinBot, profile_dir: Path) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+
+    jgbot.set_axis_absolute(IN_AXIS_1, -0.11)
+    jgbot.set_axis_absolute(IN_AXIS_1, -0.22)
+    jgbot.set_axis_absolute(IN_AXIS_1, -0.33)
+
+    assert EventSpec(InputType.JoystickButton, OUT_BUTTON_2, True) == jgbot.next_event()
+    assert (
+        EventSpec(InputType.JoystickButton, OUT_BUTTON_2, False) == jgbot.next_event()
+    )
+
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()
+
+
+def test_accumulator_resets_after_trigger(
+    jgbot: JoystickGremlinBot, profile_dir: Path
+) -> None:
+    jgbot.load_profile(profile_dir / "axis_delta.xml")
+
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.0)
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.35)
+
+    # Consume the first pulse.
+    jgbot.next_event()
+    jgbot.next_event()
+    jgbot.clear_events()
+
+    # After reset the accumulator is 0.0; a small move should not trigger.
+    jgbot.set_axis_absolute(IN_AXIS_1, 0.45)
+
+    with pytest.raises(jgbot.qtbot.TimeoutError):
+        jgbot.next_event()

--- a/test/unit/test_action_axis_delta.py
+++ b/test/unit/test_action_axis_delta.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8; -*-
+
+# SPDX-License-Identifier: GPL-3.0-only
+
+import sys
+
+sys.path.append(".")
+
+import uuid
+from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
+
+import action_plugins.axis_delta as axis_delta
+import gremlin.types as types
+from action_plugins.description import DescriptionData
+from gremlin.config import Configuration
+from gremlin.error import GremlinError
+from gremlin.profile import Library, Profile
+from gremlin.types import DataInsertionMode
+
+_ACTION_AXIS_DELTA_SIMPLE = "action_axis_delta_simple.xml"
+
+_AXIS_DELTA_ID = uuid.UUID("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
+_POSITIVE_CHILD_ID = uuid.UUID("11111111-2222-4333-8444-555555555555")
+_NEGATIVE_CHILD_ID = uuid.UUID("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+
+
+def test_ctor() -> None:
+    a = axis_delta.AxisDeltaData(types.InputType.JoystickAxis)
+    c = Configuration()
+
+    assert len(a.actions_positive) == 0
+    assert len(a.actions_negative) == 0
+    assert a.change_threshold == c.value("action", "axis-delta", "threshold")
+    assert a.is_valid() == True
+
+
+def test_from_xml(xml_dir: Path) -> None:
+    p = Profile()
+    p.from_xml(Path(xml_dir / _ACTION_AXIS_DELTA_SIMPLE))
+
+    a = p.library.get_action(_AXIS_DELTA_ID)
+
+    assert a.change_threshold == pytest.approx(0.25)
+    assert len(a.actions_positive) == 1
+    assert len(a.actions_negative) == 1
+    assert a.actions_positive[0].id == _POSITIVE_CHILD_ID
+    assert a.actions_negative[0].id == _NEGATIVE_CHILD_ID
+
+
+def test_to_xml() -> None:
+    pos_child = DescriptionData()
+    pos_child._id = uuid.UUID("11111111-2222-4333-8444-555555555555")
+
+    neg_child = DescriptionData()
+    neg_child._id = uuid.UUID("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+
+    a = axis_delta.AxisDeltaData(types.InputType.JoystickAxis)
+    a.insert_action(pos_child, "positive")
+    a.insert_action(neg_child, "negative")
+    a.change_threshold = 0.42
+
+    node = a._to_xml()
+
+    assert node.find("./property/name[.='threshold']/../value").text == "0.42"
+    assert (
+        node.find("./positive-actions/action-id").text
+        == "11111111-2222-4333-8444-555555555555"
+    )
+    assert (
+        node.find("./negative-actions/action-id").text
+        == "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+    )
+
+
+def test_action_methods(xml_dir: Path) -> None:
+    p = Profile()
+    p.from_xml(Path(xml_dir / _ACTION_AXIS_DELTA_SIMPLE))
+
+    a = p.library.get_action(_AXIS_DELTA_ID)
+
+    # get_actions returns all actions across both containers
+    assert len(a.get_actions()[0]) == 2
+    assert len(a.get_actions("positive")[0]) == 1
+    assert len(a.get_actions("negative")[0]) == 1
+
+    with pytest.raises(GremlinError):
+        a.get_actions("invalid")
+
+    # insert and remove
+    extra = DescriptionData()
+    a.insert_action(extra, "positive")
+    assert len(a.get_actions("positive")[0]) == 2
+
+    a.remove_action(0, "positive")
+    assert len(a.get_actions("positive")[0]) == 1
+
+    a.insert_action(extra, "negative", DataInsertionMode.Prepend)
+    assert len(a.get_actions("negative")[0]) == 2
+    assert a.get_actions("negative")[0][0].id == extra.id

--- a/test/unit/test_action_axis_delta.py
+++ b/test/unit/test_action_axis_delta.py
@@ -8,7 +8,6 @@ sys.path.append(".")
 
 import uuid
 from pathlib import Path
-from xml.etree import ElementTree
 
 import pytest
 
@@ -17,10 +16,10 @@ import gremlin.types as types
 from action_plugins.description import DescriptionData
 from gremlin.config import Configuration
 from gremlin.error import GremlinError
-from gremlin.profile import Library, Profile
+from gremlin.profile import Profile
 from gremlin.types import DataInsertionMode
 
-_ACTION_AXIS_DELTA_SIMPLE = "action_axis_delta_simple.xml"
+_XML_PROFILE = "action_axis_delta_simple.xml"
 
 _AXIS_DELTA_ID = uuid.UUID("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
 _POSITIVE_CHILD_ID = uuid.UUID("11111111-2222-4333-8444-555555555555")
@@ -34,15 +33,16 @@ def test_ctor() -> None:
     assert len(a.actions_positive) == 0
     assert len(a.actions_negative) == 0
     assert a.change_threshold == c.value("action", "axis-delta", "threshold")
-    assert a.is_valid() == True
+    assert a.is_valid()
 
 
 def test_from_xml(xml_dir: Path) -> None:
     p = Profile()
-    p.from_xml(Path(xml_dir / _ACTION_AXIS_DELTA_SIMPLE))
+    p.from_xml(Path(xml_dir / _XML_PROFILE))
 
     a = p.library.get_action(_AXIS_DELTA_ID)
 
+    assert isinstance(a, axis_delta.AxisDeltaData)
     assert a.change_threshold == pytest.approx(0.25)
     assert len(a.actions_positive) == 1
     assert len(a.actions_negative) == 1
@@ -77,7 +77,7 @@ def test_to_xml() -> None:
 
 def test_action_methods(xml_dir: Path) -> None:
     p = Profile()
-    p.from_xml(Path(xml_dir / _ACTION_AXIS_DELTA_SIMPLE))
+    p.from_xml(Path(xml_dir / _XML_PROFILE))
 
     a = p.library.get_action(_AXIS_DELTA_ID)
 
@@ -90,13 +90,14 @@ def test_action_methods(xml_dir: Path) -> None:
         a.get_actions("invalid")
 
     # insert and remove
-    extra = DescriptionData()
-    a.insert_action(extra, "positive")
+    description_action = DescriptionData()
+    a.insert_action(description_action, "positive")
     assert len(a.get_actions("positive")[0]) == 2
 
     a.remove_action(0, "positive")
     assert len(a.get_actions("positive")[0]) == 1
+    assert a.get_actions("positive")[0][0].id == description_action.id
 
-    a.insert_action(extra, "negative", DataInsertionMode.Prepend)
+    a.insert_action(description_action, "negative", DataInsertionMode.Prepend)
     assert len(a.get_actions("negative")[0]) == 2
-    assert a.get_actions("negative")[0][0].id == extra.id
+    assert a.get_actions("negative")[0][0].id == description_action.id

--- a/test/unit/xml/action_axis_delta_simple.xml
+++ b/test/unit/xml/action_axis_delta_simple.xml
@@ -1,0 +1,60 @@
+<profile version="14">
+    <settings>
+        <startup-mode>Default</startup-mode>
+        <macro-default-delay>0.05</macro-default-delay>
+    </settings>
+
+    <library>
+        <action id="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" type="axis-delta">
+            <property type="float">
+                <name>threshold</name>
+                <value>0.25</value>
+            </property>
+            <positive-actions>
+                <action-id>11111111-2222-4333-8444-555555555555</action-id>
+            </positive-actions>
+            <negative-actions>
+                <action-id>aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee</action-id>
+            </negative-actions>
+            <property type="string">
+                <name>action-label</name>
+                <value></value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+
+        <action id="11111111-2222-4333-8444-555555555555" type="description">
+            <property type="string">
+                <name>description</name>
+                <value>positive</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value></value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+
+        <action id="aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" type="description">
+            <property type="string">
+                <name>description</name>
+                <value>negative</value>
+            </property>
+            <property type="string">
+                <name>action-label</name>
+                <value></value>
+            </property>
+            <property type="activation-mode">
+                <name>activation-mode</name>
+                <value>disallowed</value>
+            </property>
+        </action>
+    </library>
+
+</profile>


### PR DESCRIPTION
Implements an action that triggers a set of actions whenever a set threshold of cumulative axis change has been accumulated. The action differentiates between positive and negative accumulated change such that both directions can be used to trigger different actions. The action does not attempt to ensure an exact matching number of actions is executed if the physical device fails to emit events at a high enough frequency or resolution. This implements a solution to #115.