### PR TITLE
Don't strip Qt6Multimedia.dll from the frozen build (fixes TTS at startup)

### DIFF
--- a/joystick_gremlin.spec
+++ b/joystick_gremlin.spec
@@ -98,7 +98,10 @@ to_exclude = [
     "Qt6DataVisualizationQml.dll",
     "Qt6Graphs.dll",
     "Qt6Location.dll",
-    "Qt6Multimedia.dll",
+    # Keep Qt6Multimedia.dll: newer PySide6 (6.11+) makes QtTextToSpeech depend
+    # on it, and gremlin.tts imports QtTextToSpeech at startup, so excluding it
+    # breaks the frozen build with "DLL load failed while importing
+    # QtTextToSpeech". Qt6MultimediaQuick (QML multimedia) is still unused.
     "Qt6MultimediaQuick.dll",
     "Qt6Pdf.dll",
     "Qt6PdfQuick.dll",


### PR DESCRIPTION
### Problem

The frozen-build spec strips `Qt6Multimedia.dll` via the `to_exclude` list. Since the text-to-speech action (#768) was merged, `gremlin.tts` imports `QtTextToSpeech` at startup, and on PySide6 6.11+ `QtTextToSpeech` depends on `Qt6Multimedia`. As a result a frozen build now fails at launch with:

```
ImportError: DLL load failed while importing QtTextToSpeech: The specified module could not be found.
```

So the current spec produces a broken executable whenever the TTS action's module is loaded.

### Fix

Keep `Qt6Multimedia.dll` in the bundle (remove it from `to_exclude`), with a comment explaining the dependency. `Qt6MultimediaQuick.dll` (the QML multimedia module) is still unused and stays excluded, so the size impact is just the one DLL.

```diff
     "Qt6DataVisualizationQml.dll",
     "Qt6Graphs.dll",
     "Qt6Location.dll",
-    "Qt6Multimedia.dll",
+    # Keep Qt6Multimedia.dll: newer PySide6 (6.11+) makes QtTextToSpeech depend
+    # on it, and gremlin.tts imports QtTextToSpeech at startup, so excluding it
+    # breaks the frozen build with "DLL load failed while importing
+    # QtTextToSpeech". Qt6MultimediaQuick (QML multimedia) is still unused.
     "Qt6MultimediaQuick.dll",
```

### Verification

Built `joystick_gremlin.spec` with this change and confirmed the resulting `dist/joystick_gremlin/joystick_gremlin.exe` launches and runs (including TTS) with no hand-copied DLLs. Without the change, the same build hits the `QtTextToSpeech` DLL-load error at startup.
