### PR TITLE
Fix issues in creating executable builds

### DIFF
--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -407,13 +407,11 @@ class JoystickGremlinApp(QtWidgets.QApplication):
 
         # Create application and UI engine.
         self.engine = QtQml.QQmlApplicationEngine(parent=self)
-        self.engine.addImportPath(".")
-        self.engine.addImportPath("qml")
-        self.engine.addImportPath("theme")
+        self.engine.addImportPath(gremlin.util.resource_path("theme"))
 
         QtQml.qmlRegisterSingletonType(
             QtCore.QUrl.fromLocalFile(
-                str(Path(__file__).parent / "qml" / "Style.qml")
+                gremlin.util.resource_path("qml/Style.qml")
             ),
             "Gremlin.Style", 1, 0, "Style"
         )

--- a/joystick_gremlin.spec
+++ b/joystick_gremlin.spec
@@ -14,6 +14,7 @@ for root, _, files in os.walk("action_plugins"):
 datas = [
     ("gfx", "gfx"),
     ("qml", "qml"),
+    ("theme", "theme"),
     ("device_db.json", "."),
     ("version.json", ".")
 ]
@@ -52,6 +53,7 @@ hidden_imports = [
     "action_plugins.smart_toggle",
     "action_plugins.split_axis",
     "action_plugins.tempo",
+    "action_plugins.text_to_speech",
     "gremlin.ui",
     "gremlin.ui.action_model",
     "gremlin.ui.backend",
@@ -98,8 +100,6 @@ to_exclude = [
     "Qt6DataVisualizationQml.dll",
     "Qt6Graphs.dll",
     "Qt6Location.dll",
-    "Qt6Multimedia.dll",
-    "Qt6MultimediaQuick.dll",
     "Qt6Pdf.dll",
     "Qt6PdfQuick.dll",
     "Qt6Positioning.dll",


### PR DESCRIPTION
- No longer removing QtMultimedia related libraries
- Copy theme data to executable build
- Fix path specifications to work in both developer and binary execution