### PR TITLE
Apply UI config changes live without requiring a restart

### DIFF
--- a/gremlin/ui/option.py
+++ b/gremlin/ui/option.py
@@ -31,6 +31,7 @@ from gremlin.error import (
     GremlinError,
     MissingImplementationError,
 )
+from gremlin.signal import signal
 from gremlin.tts import TTSManager
 from gremlin.types import PropertyType
 
@@ -250,6 +251,8 @@ class ConfigEntryModel(QtCore.QAbstractListModel):
 
             self._config.set(*key, value)
             self.dataChanged.emit(index, index, {role})
+            # Enable other UI elements to react to configuration changes.
+            signal.configChanged.emit()
             return True
         return False
 

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -168,7 +168,7 @@ def register_config_options() -> None:
     cfg.register(
         "global", "general", "dark-mode",
         PropertyType.Bool, False,
-        "Use the dark mode UI (requires restart).", {}, True
+        "Use the dark mode UI.", {}, True
     )
     cfg.register(
         "global", "general", "refresh-axis-on-activation",

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -31,6 +31,7 @@ ApplicationWindow {
     Component.onCompleted: () => {
         Style.isDarkMode = backend.useDarkMode
     }
+
     Universal.theme: Style.theme
     color: Style.background
 
@@ -426,6 +427,12 @@ ApplicationWindow {
     }
     Connections {
         target: signal
+
+        // Re-apply UI config (e.g. dark mode) live, so toggling it in the
+        // options takes effect immediately instead of needing a restart.
+        function onConfigChanged() {
+            Style.isDarkMode = backend.useDarkMode
+        }
 
         function onShowError(message, details) {
             _errorDialog.text = message


### PR DESCRIPTION
Config changes that affect the UI — dark mode being the obvious one — currently only take effect on restart. This emits the existing `configChanged` signal when a config entry is written and has `Main.qml` re-apply on it, so toggling dark mode updates the palette immediately.

Per your note on #778, treat this as a starting point rather than a finished design — it's the smallest thing that works. If there's a direction you'd rather Gremlin take for live config, I'm glad to redo it that way; I mostly wanted something concrete to react to.

Scoped to dark mode for now. Action-icon glyphs won't recolor live yet since they're cached — that's a separate follow-up, not in here.
