### PR TITLE
Expose QML Universal theme colors

### DIFF
--- a/gremlin/ui/util.py
+++ b/gremlin/ui/util.py
@@ -28,6 +28,7 @@ from gremlin import (
     shared_state,
     windows_event_hook,
 )
+from gremlin.common import SingletonMetaclass
 from gremlin.config import Configuration
 from gremlin.keyboard import key_from_code
 from gremlin.macro import (
@@ -451,6 +452,42 @@ class ProcessListModel(QtCore.QAbstractListModel):
         if role == QtCore.Qt.ItemDataRole.DisplayRole:
             return self._processes[index.row()]
         return ""
+
+
+class ColorInformation(metaclass=SingletonMetaclass):
+
+    """Contains the information about the primary colors of the UI theme.
+
+    Information is provided via a QML object (ColorInformation.qml) that holds the
+    color information of the Universal theme as properties.
+    """
+
+    def __init__(self) -> None:
+        self._accent_color = QtCore.Qt.GlobalColor.red
+        self._background_color = QtCore.Qt.GlobalColor.white
+        self._foreground_color = QtCore.Qt.GlobalColor.black
+
+    def update_colors(self, color_information: QtCore.QObject) -> None:
+        self._accent_color = color_information.property("accent")
+        self._background_color = color_information.property("background")
+        self._foreground_color = color_information.property("foreground")
+        self._is_dark_theme = color_information.property("isDarkTheme")
+
+    @property
+    def accent(self) -> QtCore.Qt.GlobalColor:
+        return self._accent_color
+
+    @property
+    def background(self) -> QtCore.Qt.GlobalColor:
+        return self._background_color
+
+    @property
+    def foreground(self) -> QtCore.Qt.GlobalColor:
+        return self._foreground_color
+
+    @property
+    def is_dark_theme(self) -> bool:
+        return self._is_dark_theme
 
 
 def to_local_path(path_or_url: str) -> Path:

--- a/gremlin/ui/util.py
+++ b/gremlin/ui/util.py
@@ -17,6 +17,7 @@ from typing import (
 
 from PySide6 import (
     QtCore,
+    QtGui,
     QtQml,
 )
 
@@ -463,9 +464,10 @@ class ColorInformation(metaclass=SingletonMetaclass):
     """
 
     def __init__(self) -> None:
-        self._accent_color = QtCore.Qt.GlobalColor.red
-        self._background_color = QtCore.Qt.GlobalColor.white
-        self._foreground_color = QtCore.Qt.GlobalColor.black
+        self._accent_color = QtGui.QColor("blue")
+        self._background_color = QtGui.QColor("white")
+        self._foreground_color = QtGui.QColor("black")
+        self._is_dark_theme = False
 
     def update_colors(self, color_information: QtCore.QObject) -> None:
         self._accent_color = color_information.property("accent")
@@ -474,15 +476,15 @@ class ColorInformation(metaclass=SingletonMetaclass):
         self._is_dark_theme = color_information.property("isDarkTheme")
 
     @property
-    def accent(self) -> QtCore.Qt.GlobalColor:
+    def accent(self) -> QtGui.QColor:
         return self._accent_color
 
     @property
-    def background(self) -> QtCore.Qt.GlobalColor:
+    def background(self) -> QtGui.QColor:
         return self._background_color
 
     @property
-    def foreground(self) -> QtCore.Qt.GlobalColor:
+    def foreground(self) -> QtGui.QColor:
         return self._foreground_color
 
     @property

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -352,6 +352,10 @@ class JoystickGremlinApp(QtWidgets.QApplication):
         self.main_window = self.engine.rootObjects()[0]
         self.color_information_object = \
             self.main_window.findChild(QtCore.QObject, "colorInformation")
+        if self.color_information_object is None:
+            raise gremlin.error.GremlinError(
+                "Failed to find color information object in QML."
+            )
         gremlin.ui.util.ColorInformation().update_colors(self.color_information_object)
         self.color_information_object.isDarkThemeChanged.connect(
             lambda: gremlin.ui.util.ColorInformation().update_colors(

--- a/joystick_gremlin.py
+++ b/joystick_gremlin.py
@@ -348,6 +348,16 @@ class JoystickGremlinApp(QtWidgets.QApplication):
         self.process_cmd_args(cmd_args)
         self.backend.check_for_updates()
 
+        # Retrieve color information from QML for Python usage.
+        self.main_window = self.engine.rootObjects()[0]
+        self.color_information_object = \
+            self.main_window.findChild(QtCore.QObject, "colorInformation")
+        gremlin.ui.util.ColorInformation().update_colors(self.color_information_object)
+        self.color_information_object.isDarkThemeChanged.connect(
+            lambda: gremlin.ui.util.ColorInformation().update_colors(
+                self.color_information_object)
+        )
+
         # Run UI.
         self.syslog.info("Gremlin UI launching")
         self.aboutToQuit.connect(shutdown_cleanup)

--- a/qml/ColorInformation.qml
+++ b/qml/ColorInformation.qml
@@ -1,0 +1,19 @@
+// -*- coding: utf-8; -*-
+// SPDX-License-Identifier: GPL-3.0-only
+
+import QtQuick
+import QtQuick.Controls.Universal
+import Gremlin.Style
+
+Item {
+    objectName: "colorInformation"
+
+    Universal.theme: Style.theme
+
+    // Capture color values of interest from the Universal theme to expose to
+    // Python.
+    property color accent: Universal.accent
+    property color background: Universal.background
+    property color foreground: Universal.foreground
+    property bool isDarkTheme: Universal.theme === Universal.Dark
+}

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,6 +34,10 @@ ApplicationWindow {
     Universal.theme: Style.theme
     color: Style.background
 
+    ColorInformation {
+        id: colorInformation
+    }
+
     ErrorDialog {
         id: _errorDialog
 


### PR DESCRIPTION
Exposes core colors (accent, foreground, background) and theme style (dark / light) that normally is only available to QML code via an object to Python.