### PR TITLE
Make inactive device tab labels legible in dark mode

### DIFF
--- a/qml/JGTabButton.qml
+++ b/qml/JGTabButton.qml
@@ -10,6 +10,16 @@ TabButton {
     font.pixelSize: 14
     font.weight: 600
 
+    contentItem: Text {
+        text: parent.text
+        font: parent.font
+        // Active tab at full strength; inactive tabs muted but still legible.
+        color: parent.checked ? Style.foreground : Style.medColor
+
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+
     background: Rectangle {
         color: parent.checked ? Style.accent : Style.background
     }


### PR DESCRIPTION
`JGTabButton` only styled the tab background, so inactive labels fell back to Universal's default dimming and read as disabled. Active tab now uses the full foreground colour, inactive tabs use the palette's `medColor` — legible but clearly unselected. Uses existing `Style` palette roles only.
