### PR TITLE
#802 - Vjoy Axis Condition Fix

### DIFF
--- a/action_plugins/condition/condition.py
+++ b/action_plugins/condition/condition.py
@@ -404,7 +404,7 @@ class VJoyCondition(AbstractCondition):
     def _set_vjoy_input_type(self, input_type: str) -> None:
         input_type_tmp = InputType.to_enum(input_type)
         if input_type_tmp != self._states[0].input_type:
-            self._create_comparator(self._sates[0].input_type)
+            self._create_comparator(input_type_tmp)
             self._update_states(
                 [
                     self.State(


### PR DESCRIPTION
See: https://github.com/WhiteMagic/JoystickGremlin/issues/802

Fix for vjoy axis condition exception, and that it would display the condition controls for a button instead of an axis range.

This change now will actually show the range controls for the vjoy axis, and appears to be working as expected from a quick test here.

<img width="1187" height="154" alt="image" src="https://github.com/user-attachments/assets/fca6db12-20bd-4d21-8393-363bee8f8eb1" />
